### PR TITLE
Allow React front‑end on port 8080

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,9 +342,10 @@ Pour lancer le système complet, le GRA et tous les agents doivent être démarr
 
     Vous pouvez également tester une interface React très simple disponible dans le dossier `react_frontend` :
     ```bash
-    cd react_frontend && python -m http.server 8000
+    cd react_frontend && python -m http.server 8080
     ```
-    Puis ouvrez [http://localhost:8000/index.html](http://localhost:8000/index.html).
+    Puis ouvrez [http://localhost:8080/index.html](http://localhost:8080/index.html).
+    L'API backend reste disponible sur `http://localhost:8000`. Si besoin, vous pouvez spécifier une autre URL en définissant `BACKEND_API_URL` avant de charger les scripts.
 
 4.  **Utilisez l'Interface** :
     * Soumettez un nouvel objectif.

--- a/react_frontend/README.md
+++ b/react_frontend/README.md
@@ -8,11 +8,11 @@ This folder contains a minimal React interface to visualize and interact with th
 2. Start a simple HTTP server in this directory:
    ```bash
    cd react_frontend
-   python -m http.server 8000
+   python -m http.server 8080
    ```
-3. Open [http://localhost:8000/index.html](http://localhost:8000/index.html) in your browser.
+3. Open [http://localhost:8080/index.html](http://localhost:8080/index.html) in your browser.
 
-The interface fetches data from `http://localhost:8000` by default. You can override the backend URL by setting `BACKEND_API_URL` as a global variable before loading the scripts:
+The interface fetches data from `http://localhost:8000` by default (backend API). You can override this URL by setting `BACKEND_API_URL` as a global variable before loading the scripts:
 
 ```html
 <script>

--- a/src/services/gra/server.py
+++ b/src/services/gra/server.py
@@ -2,6 +2,7 @@
 import uvicorn
 import logging
 from fastapi import FastAPI, HTTPException, Body, Path
+from fastapi.middleware.cors import CORSMiddleware
 from typing import Dict, Any, List, Optional
 import firebase_admin
 from firebase_admin import credentials, firestore
@@ -140,6 +141,15 @@ app = FastAPI(
     description="Service central pour l'enregistrement des agents et le stockage des artefacts.",
     version="1.0.0",
     lifespan=lifespan
+)
+
+# Allow CORS for the React interface served on http://localhost:8080
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:8080"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
 
 # --- Endpoints Agents et Artefacts existants (inchangés pour l'instant) ---


### PR DESCRIPTION
## Summary
- add CORSMiddleware for requests from the React UI
- document serving the React interface with `python -m http.server 8080`
- mention backend API location and how to override it

## Testing
- `python -m pip install -q -r requirements.txt`
- `pip install -q google-generativeai`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684404f56dcc832d8a0adedf573fcaf9