### PR TITLE
Add clarification chat to React frontend

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -82,3 +82,18 @@ textarea {
   border-radius: 4px;
   padding: 0.25rem 0.5rem;
 }
+
+.clarification-block {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  background: #fafafa;
+}
+.chat-history {
+  max-height: 200px;
+  overflow-y: auto;
+  margin-bottom: 0.5rem;
+}
+.chat-item {
+  margin-bottom: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- show clarification chat when plan requires user input
- allow sending responses and forcing TEAM 1
- style clarification block

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68443455cdbc832d8853eaaa58c96b2b