### PR TITLE
Add plan details display to React UI

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -97,3 +97,14 @@ textarea {
 .chat-item {
   margin-bottom: 0.25rem;
 }
+
+.plan-info {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  background: #fafafa;
+}
+
+.plan-stats pre {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- show selected plan info and execution status in React dashboard
- compute plan statistics for team graphs
- display plan statistics section
- add styling for plan info box

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install google-generativeai`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443e4f7f08832daa5c38601109b0cb