### PR TITLE
Improve plan detail info styling and fail indicators

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -1,4 +1,11 @@
 const BACKEND_API_URL = window.BACKEND_API_URL || 'http://localhost:8000';
+const FINISHED_STATES = [
+  'TEAM2_EXECUTION_COMPLETED',
+  'TEAM2_EXECUTION_FAILED',
+  'TEAM1_PLANNING_FAILED',
+  'FAILED_MAX_CLARIFICATION_ATTEMPTS',
+  'FAILED_AGENT_ERROR'
+];
 
 function Graph({ nodes, edges, onNodeClick, onEdgeClick }) {
   const containerRef = React.useRef(null);
@@ -71,6 +78,73 @@ function AgentStatusBar({ agents }) {
   );
 }
 
+function PlanInfo({ plan, flowRunning }) {
+  if (!plan) return null;
+  const stateClass =
+    plan.current_supervisor_state?.includes('FAILED')
+      ? 'failed'
+      : plan.current_supervisor_state?.includes('COMPLETED')
+      ? 'completed'
+      : '';
+  return (
+    <div className="plan-info">
+      <div><strong>Plan ID:</strong> {plan.global_plan_id}</div>
+      <div><strong>Objectif brut:</strong> {plan.raw_objective}</div>
+      {plan.clarified_objective && (
+        <div><strong>Objectif clarifié:</strong> {plan.clarified_objective}</div>
+      )}
+      <div className={stateClass}>
+        <strong>État actuel:</strong> {plan.current_supervisor_state}
+      </div>
+      <div>
+        <strong>Flux en cours:</strong> {flowRunning ? '🟢 Oui' : '🏁 Terminé'}
+      </div>
+    </div>
+  );
+}
+
+function PlanStats({ team1Counts, team2Counts }) {
+  if (!team1Counts && !team2Counts) return null;
+
+  const renderStats = counts => (
+    <>
+      <ul>
+        {Object.entries(counts).map(([state, num]) => (
+          <li
+            key={state}
+            className={state === 'failed' || state === 'unable_to_complete' ? 'fail-count' : ''}
+          >
+            {state}: {num}
+          </li>
+        ))}
+      </ul>
+      {(counts.failed || counts.unable_to_complete) && (
+        <div className="fail-summary">
+          ❌ {(counts.failed || 0) + (counts.unable_to_complete || 0)} tâche(s) en échec
+        </div>
+      )}
+    </>
+  );
+
+  return (
+    <details className="plan-stats">
+      <summary>📊 Statistiques du plan</summary>
+      {team1Counts && (
+        <div className="stat-group">
+          <strong>TEAM 1</strong>
+          {renderStats(team1Counts)}
+        </div>
+      )}
+      {team2Counts && (
+        <div className="stat-group">
+          <strong>TEAM 2</strong>
+          {renderStats(team2Counts)}
+        </div>
+      )}
+    </details>
+  );
+}
+
 function App() {
   const [plans, setPlans] = React.useState([]);
   const [selectedPlanId, setSelectedPlanId] = React.useState('');
@@ -83,6 +157,8 @@ function App() {
   const [agentsStatus, setAgentsStatus] = React.useState([]);
   const [newObjective, setNewObjective] = React.useState('');
   const [autoRefresh, setAutoRefresh] = React.useState(false);
+  const [team1Counts, setTeam1Counts] = React.useState(null);
+  const [team2Counts, setTeam2Counts] = React.useState(null);
 
   React.useEffect(() => {
     fetch(`${BACKEND_API_URL}/v1/global_plans_summary`)
@@ -120,7 +196,10 @@ function App() {
             .then(d => {
               setTeam1NodesMap(d.nodes || {});
               setTeam1Graph(parseTaskGraph(d.nodes, true));
+              setTeam1Counts(computeStateCounts(d.nodes));
             });
+        } else {
+          setTeam1Counts(null);
         }
         if (plan.team2_execution_plan_id) {
           fetch(`${BACKEND_API_URL}/v1/execution_task_graphs/${plan.team2_execution_plan_id}`)
@@ -128,10 +207,12 @@ function App() {
             .then(d => {
               setTeam2NodesMap(d.nodes || {});
               setTeam2Graph(parseTaskGraph(d.nodes, false));
+              setTeam2Counts(computeStateCounts(d.nodes));
             });
         } else {
           setTeam2Graph(null);
           setTeam2NodesMap({});
+          setTeam2Counts(null);
         }
       })
       .catch(err => console.error('Erreur chargement details plan', err));
@@ -158,6 +239,16 @@ function App() {
       });
     });
     return { nodes, edges };
+  }
+
+  function computeStateCounts(nodesObj) {
+    if (!nodesObj) return null;
+    const counts = {};
+    Object.values(nodesObj).forEach(n => {
+      const state = n.state || 'unknown';
+      counts[state] = (counts[state] || 0) + 1;
+    });
+    return counts;
   }
 
   function submitNewPlan() {
@@ -322,6 +413,8 @@ function App() {
             Auto-refresh
           </label>
         </div>
+        <PlanInfo plan={planDetails} flowRunning={planDetails && !FINISHED_STATES.includes(planDetails.current_supervisor_state)} />
+        <PlanStats team1Counts={team1Counts} team2Counts={team2Counts} />
         {planDetails?.current_supervisor_state === 'CLARIFICATION_PENDING_USER_INPUT' && (
           <ClarificationSection plan={planDetails} />
         )}

--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -97,3 +97,45 @@ textarea {
 .chat-item {
   margin-bottom: 0.25rem;
 }
+
+.plan-info {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  background: #fafafa;
+}
+.plan-info div {
+  margin-bottom: 0.25rem;
+}
+.plan-info .failed {
+  color: #c62828;
+  font-weight: bold;
+}
+.plan-info .completed {
+  color: #2e7d32;
+}
+
+.plan-stats pre {
+  margin: 0;
+}
+
+.plan-stats ul {
+  list-style: none;
+  padding-left: 0;
+}
+.plan-stats .stat-group {
+  margin-bottom: 0.5rem;
+}
+.plan-stats li {
+  margin-bottom: 0.25rem;
+}
+.plan-stats li.fail-count {
+  color: #c62828;
+  font-weight: bold;
+}
+
+.fail-summary {
+  color: #c62828;
+  font-weight: bold;
+  margin-top: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- refine plan information layout in React dashboard
- highlight failed plan states and failed task counts
- style stats and detail sections for better readability

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install google-generativeai`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68443e4f7f08832daa5c38601109b0cb