### PR TITLE
Improve plan detail with failure indicators

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -105,6 +105,26 @@ textarea {
   background: #fafafa;
 }
 
+.plan-info-failure {
+  color: #721c24;
+  font-weight: bold;
+}
+
+.plan-stats-table {
+  border-collapse: collapse;
+  margin-bottom: 0.5rem;
+}
+
+.plan-stats-table td {
+  border: 1px solid #ccc;
+  padding: 0.25rem 0.5rem;
+}
+
+.plan-stats-table .failed-state td {
+  background: #f8d7da;
+  font-weight: bold;
+}
+
 .plan-stats pre {
   margin: 0;
 }


### PR DESCRIPTION
## Summary
- enhance plan detail display in React frontend
- show warning when tasks failed and highlight failing states
- style tables for plan statistics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68445d3618d8832dbcce9912e7cc755c