### PR TITLE
Add continue_execution function

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Après la validation du plan détaillé par TEAM 1, cette nouvelle phase prend e
         * L'agent sélectionné exécute la tâche et produit des artefacts (ex: code source, rapport de recherche, rapport de test).
     * **Gestion des Tâches Exploratoires** : Les tâches de type `exploratory` (souvent gérées par `ResearchAgent`) peuvent retourner des résultats qui incluent la définition de nouvelles sous-tâches, enrichissant dynamiquement l'`ExecutionTaskGraph`.
 * **Suivi et Finalisation** : `ExecutionSupervisorLogic` suit l'état de toutes les tâches d'exécution. Une fois toutes les tâches terminées, l'état global du plan d'exécution (`EXECUTION_COMPLETED_SUCCESSFULLY` ou `EXECUTION_COMPLETED_WITH_FAILURES`) est déterminé. Le `GlobalSupervisorLogic` met à jour l'état du `global_plan` en conséquence.
+* **Reprise d'un Plan en Cours** : la nouvelle méthode `continue_execution` permet de relancer un plan existant lorsque des tâches demeurent en `pending` ou `ready`. Un bouton "Reprendre l'exécution" est disponible dans l'interface React pour déclencher cette action.
 
 ### Capacités Transverses :
 

--- a/react_frontend/README.md
+++ b/react_frontend/README.md
@@ -25,3 +25,5 @@ The interface fetches data from `http://localhost:8000` by default (backend API)
 - `index.html` – entry point including CDN imports for React and Vis Network.
 - `app.jsx` – main React application (loaded via Babel in the browser).
 - `style.css` – simple styling for the dashboard.
+
+The dashboard now exposes a **Reprendre l'exécution** button when a plan TEAM 2 is incomplete. Clicking it calls the `/v1/global_plans/<id>/resume_execution` API to continue pending tasks.

--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -262,6 +262,16 @@ function App() {
       .catch(err => console.error('Erreur soumission plan', err));
   }
 
+  function resumeExecution(planId) {
+    if (!planId) return;
+    fetch(`${BACKEND_API_URL}/v1/global_plans/${planId}/resume_execution`, {
+      method: 'POST'
+    })
+      .then(r => r.json())
+      .then(() => refreshPlanDetails(planId))
+      .catch(err => console.error('Erreur reprise execution', err));
+  }
+
   function formatArtifact(data) {
     if (!data) return '';
     if (typeof data === 'string') {
@@ -412,6 +422,14 @@ function App() {
           flowRunning={planDetails && !FINISHED_STATES.includes(planDetails.current_supervisor_state)}
           hasFailures={hasFailures}
         />
+        {planDetails?.team2_execution_plan_id &&
+          planDetails.current_supervisor_state !== 'TEAM2_EXECUTION_COMPLETED' && (
+            <div style={{ marginBottom: '0.5rem' }}>
+              <button onClick={() => resumeExecution(planDetails.global_plan_id)}>
+                Reprendre l'exécution TEAM 2
+              </button>
+            </div>
+          )}
         <PlanStats team1Counts={team1Counts} team2Counts={team2Counts} />
         {planDetails?.current_supervisor_state === 'CLARIFICATION_PENDING_USER_INPUT' && (
           <ClarificationSection plan={planDetails} />

--- a/src/services/gra/server.py
+++ b/src/services/gra/server.py
@@ -521,6 +521,21 @@ async def accept_objective_and_trigger_team1_planning(
         logger.error(f"[GRA API] Erreur lors de l'acceptation de l'objectif pour plan '{global_plan_id}': {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Erreur interne du serveur: {str(e)}")
 
+
+@app.post("/v1/global_plans/{global_plan_id}/resume_execution", response_model=GlobalPlanResponse)
+async def resume_team2_execution_endpoint(global_plan_id: str = Path(..., description="ID du plan global")):
+    """Reprend l'exécution TEAM 2 pour un plan global existant."""
+    logger.info(f"[GRA API] Requête de reprise TEAM 2 pour plan '{global_plan_id}'.")
+    try:
+        supervisor = GlobalSupervisorLogic()
+        result = await supervisor.continue_team2_execution(global_plan_id)
+        return GlobalPlanResponse(**result)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Plan global '{global_plan_id}' non trouvé.")
+    except Exception as e:
+        logger.error(f"[GRA API] Erreur reprise TEAM 2 pour plan '{global_plan_id}': {e}", exc_info=True)
+        raise HTTPException(status_code=500, detail=f"Erreur interne du serveur: {str(e)}")
+
 @app.get("/v1/stats/team1_agent_tasks_count", response_model=Team1AgentTasksCountResponse)
 async def get_team1_agent_tasks_count_stats():
     """


### PR DESCRIPTION
## Summary
- allow resuming execution via an optional execution_plan_id
- expose a `continue_execution` coroutine to resume pending tasks
- add `resume_execution` API endpoint and React button to trigger it
- document the new capability in README

## Testing
- `pip install google-generativeai`
- `PYTHONPATH=. pytest -q tests/unit/test_decomposition_logic.py`

------
https://chatgpt.com/codex/tasks/task_e_684463801f64832da699fa8af252e97d