### PR TITLE
Secure React demo & robust decomposition logic

### DIFF
--- a/react_frontend/README.md
+++ b/react_frontend/README.md
@@ -27,3 +27,17 @@ The interface fetches data from `http://localhost:8000` by default (backend API)
 - `style.css` – simple styling for the dashboard.
 
 The dashboard now exposes a **Reprendre l'exécution** button when a plan TEAM 2 is incomplete. Clicking it calls the `/v1/global_plans/<id>/resume_execution` API to continue pending tasks.
+
+## Secure Serving
+
+For demo deployments you may want to protect the dashboard with a simple password.
+Run the provided `secure_server.py` script instead of `python -m http.server`:
+
+```bash
+cd react_frontend
+BASIC_AUTH_USERNAME=myuser BASIC_AUTH_PASSWORD=mypass python secure_server.py
+```
+
+The server exposes the files on port `8080` (modifiable via `PORT` environment
+variable) and requires HTTP Basic authentication with the credentials specified
+via `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`.

--- a/react_frontend/secure_server.py
+++ b/react_frontend/secure_server.py
@@ -1,0 +1,35 @@
+import base64
+import os
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+USERNAME = os.environ.get("BASIC_AUTH_USERNAME", "admin")
+PASSWORD = os.environ.get("BASIC_AUTH_PASSWORD", "demo")
+
+# Precompute the valid Authorization header value
+VALID_TOKEN = "Basic " + base64.b64encode(f"{USERNAME}:{PASSWORD}".encode()).decode()
+
+class AuthHandler(SimpleHTTPRequestHandler):
+    def do_HEAD(self):
+        if not self._check_auth():
+            return
+        super().do_HEAD()
+
+    def do_GET(self):
+        if not self._check_auth():
+            return
+        super().do_GET()
+
+    def _check_auth(self):
+        auth = self.headers.get("Authorization")
+        if auth == VALID_TOKEN:
+            return True
+        self.send_response(401)
+        self.send_header("WWW-Authenticate", 'Basic realm="React Frontend"')
+        self.end_headers()
+        return False
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 8080))
+    server = HTTPServer(("", port), AuthHandler)
+    print(f"Serving on port {port} with basic auth")
+    server.serve_forever()

--- a/src/agents/decomposition_agent/logic.py
+++ b/src/agents/decomposition_agent/logic.py
@@ -27,14 +27,15 @@ class DecompositionAgentLogic(BaseAgentLogic):
 
         try:
             input_payload = json.loads(input_data_str)
-            team1_plan_text = input_payload.get("team1_plan_text")
+            team1_plan_text = input_payload.get("team1_plan_text") or input_payload.get("plan_text")
             available_skills_list = input_payload.get("available_execution_skills", [])
-        except json.JSONDecodeError as e:
-            self.logger.error(f"DecompositionAgent: Input JSON invalide: {input_data_str}. Erreur: {e}")
-            return {"error": "Input JSON invalide pour DecompositionAgent", "details": input_data_str}
-        except AttributeError: 
-            self.logger.error(f"DecompositionAgent: input_data_str n'est pas une chaîne JSON. Reçu type: {type(input_data_str)}")
-            return {"error": "Format d'input incorrect, attendu une chaîne JSON."}
+        except (json.JSONDecodeError, TypeError) as e:
+            # Autoriser un mode plus simple où input_data_str est directement le plan texte
+            self.logger.warning(
+                "DecompositionAgent: input_data_str n'est pas un JSON valide, traitement comme texte brut"
+            )
+            team1_plan_text = input_data_str if isinstance(input_data_str, str) else str(input_data_str)
+            available_skills_list = []
 
 
         if not team1_plan_text:


### PR DESCRIPTION
## Summary
- add simple HTTP basic auth server for React demo
- document secure server usage
- make decomposition agent logic accept plain text input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684471908e48832daca73158b5157d1c