### PR TITLE
Add task type highlight in Team2 graph

### DIFF
--- a/react_frontend/README.md
+++ b/react_frontend/README.md
@@ -28,6 +28,13 @@ The interface fetches data from `http://localhost:8000` by default (backend API)
 
 The dashboard now exposes a **Reprendre l'exécution** button when a plan TEAM 2 is incomplete. Clicking it calls the `/v1/global_plans/<id>/resume_execution` API to continue pending tasks.
 
+## Node Colours
+
+In the Team&nbsp;2 execution graph, nodes now show additional visual cues:
+
+- the node border colour reflects the task type (`executable`, `exploratory`, `container`, `decomposition`),
+- nodes that have spawned sub-tasks have a thicker border.
+
 ## Secure Serving
 
 For demo deployments you may want to protect the dashboard with a simple password.

--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -216,14 +216,31 @@ function App() {
     const nodes = [];
     const edges = [];
     if (!nodesObj) return { nodes, edges };
-    Object.entries(nodesObj).forEach(([id, info]) => {
-      let color = '#d3d3d3';
-      const state = info.state;
-      if (state === 'completed') color = '#d4edda';
-      else if (state === 'failed' || state === 'unable_to_complete') color = '#f8d7da';
-      else if (state === 'working') color = '#fff3cd';
 
-      nodes.push({ id, label: (info.objective || id).slice(0,35), color });
+    const typeBorderColors = {
+      executable: '#007bff',
+      exploratory: '#ff9800',
+      container: '#888888',
+      decomposition: '#9c27b0'
+    };
+
+    Object.entries(nodesObj).forEach(([id, info]) => {
+      let bgColor = '#d3d3d3';
+      const state = info.state;
+      if (state === 'completed') bgColor = '#d4edda';
+      else if (state === 'failed' || state === 'unable_to_complete') bgColor = '#f8d7da';
+      else if (state === 'working') bgColor = '#fff3cd';
+
+      const nodeData = { id, label: (info.objective || id).slice(0, 35) };
+      if (isTeam1) {
+        nodeData.color = bgColor;
+      } else {
+        const borderColor = typeBorderColors[info.task_type] || '#000000';
+        nodeData.color = { background: bgColor, border: borderColor };
+        nodeData.borderWidth = info.sub_task_ids && info.sub_task_ids.length > 0 ? 3 : 1;
+      }
+      nodes.push(nodeData);
+
       const links = isTeam1 ? info.children : info.dependencies;
       (links || []).forEach(childId => {
         if (nodesObj[childId]) {


### PR DESCRIPTION
## Summary
- display task type via border colours and thicker outline when sub-tasks exist
- document new colours in the React README

## Testing
- `pip install -r requirements.txt`
- `pip install google-generativeai`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6844906da1bc832db75c7a442ab0388e