### PR TITLE
Add fullscreen button for Team 2 graph

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -7,9 +7,35 @@ const FINISHED_STATES = [
   'FAILED_AGENT_ERROR'
 ];
 
-function Graph({ nodes, edges, onNodeClick, onEdgeClick }) {
+function Graph({ nodes, edges, onNodeClick, onEdgeClick, allowFullscreen }) {
   const containerRef = React.useRef(null);
   const networkRef = React.useRef(null);
+  const [isFullscreen, setIsFullscreen] = React.useState(false);
+
+  const toggleFullscreen = () => {
+    const container = containerRef.current;
+    if (!container) return;
+    if (!isFullscreen) {
+      if (container.requestFullscreen) {
+        container.requestFullscreen();
+        setIsFullscreen(true);
+      }
+    } else {
+      if (document.exitFullscreen) {
+        document.exitFullscreen();
+        setIsFullscreen(false);
+      }
+    }
+  };
+
+  React.useEffect(() => {
+    const handler = () => {
+      const elem = document.fullscreenElement;
+      setIsFullscreen(elem === containerRef.current);
+    };
+    document.addEventListener('fullscreenchange', handler);
+    return () => document.removeEventListener('fullscreenchange', handler);
+  }, []);
 
   React.useEffect(() => {
     if (!containerRef.current) return;
@@ -53,6 +79,11 @@ function Graph({ nodes, edges, onNodeClick, onEdgeClick }) {
         ref={containerRef}
         style={{ height: '600px', border: '1px solid #ccc', marginBottom: '1rem' }}
       />
+      {allowFullscreen && (
+        <button className="fullscreen-button" onClick={toggleFullscreen}>
+          {isFullscreen ? 'Quitter plein écran' : 'Plein écran'}
+        </button>
+      )}
       <button className="fit-button" onClick={() => networkRef.current?.fit()}>
         Recentrer
       </button>
@@ -470,6 +501,7 @@ function App() {
               edges={team2Graph.edges}
               onNodeClick={info => onNodeClick(info, false)}
               onEdgeClick={info => onEdgeClick(info, false)}
+              allowFullscreen
             />
           </div>
         )}

--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -70,6 +70,12 @@ textarea {
   right: 10px;
   z-index: 5;
 }
+.fullscreen-button {
+  position: absolute;
+  top: 10px;
+  right: 110px;
+  z-index: 5;
+}
 
 .agent-status-bar {
   display: flex;


### PR DESCRIPTION
## Summary
- add a fullscreen toggle to the Graph component
- enable fullscreen only for Team2 graph
- style the new fullscreen button

## Testing
- `pip install httpx a2a-sdk google-generativeai`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68453a38739c832d8928d9fac932808f