### PR TITLE
Add message history of final artifacts

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -134,3 +134,21 @@ textarea {
 .plan-stats pre {
   margin: 0;
 }
+
+.messages-history {
+  margin-top: 1rem;
+}
+.message-item {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
+  background: #fafafa;
+}
+.message-item pre {
+  margin: 0;
+  white-space: pre-wrap;
+}
+.msg-date {
+  font-size: 0.8rem;
+  color: #555;
+}


### PR DESCRIPTION
## Summary
- show final task artifacts after graphs in React interface
- style the new final artifacts message list

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q` *(fails: async tests require plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68461f22ad9c832d885f43b3c1f77ae3