### PR TITLE
Improve dashboard agent status display

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -137,18 +137,32 @@ function Graph({
 function AgentStatusBar({ agents }) {
   if (!agents?.length) return null;
   return (
-    <div className="agent-status-bar">
-      {agents.map(a => (
-        <div
-          key={a.name}
-          className="agent-status"
-          title={(a.skills || []).join(', ')}
-        >
-          <span>{a.health_status || ''}</span>
-          {a.name.replace('AgentServer', '')}
-        </div>
-      ))}
-    </div>
+    <table className="agents-table">
+      <thead>
+        <tr>
+          <th>Agent</th>
+          <th>Statut</th>
+          <th>Dernière mise à jour</th>
+          <th>Public URL</th>
+        </tr>
+      </thead>
+      <tbody>
+        {agents.map(a => (
+          <tr key={a.name} title={`Skills: ${(a.skills || []).join(', ')}\nInternal: ${a.internal_url}`}>
+            <td>{a.name.replace('AgentServer', '')}</td>
+            <td className={a.health_status?.includes('Online') ? 'status-online' : 'status-offline'}>
+              {a.health_status || ''}
+            </td>
+            <td>{new Date(a.timestamp).toLocaleString()}</td>
+            <td>
+              <a href={a.public_url} target="_blank" rel="noopener noreferrer">
+                {a.public_url}
+              </a>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
   );
 }
 

--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -77,16 +77,24 @@ textarea {
   z-index: 5;
 }
 
-.agent-status-bar {
-  display: flex;
-  gap: 0.5rem;
-  flex-wrap: wrap;
+.agents-table {
+  border-collapse: collapse;
+  width: 100%;
   margin-bottom: 1rem;
 }
-.agent-status {
-  background: #f0f0f0;
-  border-radius: 4px;
+.agents-table th, .agents-table td {
+  border: 1px solid #ccc;
   padding: 0.25rem 0.5rem;
+}
+.agents-table .status-online {
+  background: #d4edda;
+  color: #155724;
+  font-weight: bold;
+}
+.agents-table .status-offline {
+  background: #f8d7da;
+  color: #721c24;
+  font-weight: bold;
 }
 
 .clarification-block {


### PR DESCRIPTION
## Summary
- restyle agent status panel as a table
- show last update time and link to agent public URL
- add online/offline styling

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68462431d7c4832db12a51f38c2e7377