### PR TITLE
Add dark theme to React frontend

### DIFF
--- a/react_frontend/README.md
+++ b/react_frontend/README.md
@@ -24,7 +24,9 @@ The interface fetches data from `http://localhost:8000` by default (backend API)
 
 - `index.html` – entry point including CDN imports for React and Vis Network.
 - `app.jsx` – main React application (loaded via Babel in the browser).
-- `style.css` – simple styling for the dashboard.
+- `style.css` – styling for the dashboard (now with a dark theme by default).
+
+The interface adopts a modern look inspired by Streamlit with the `Inter` font and dark colours.
 
 The dashboard now exposes a **Reprendre l'exécution** button when a plan TEAM 2 is incomplete. Clicking it calls the `/v1/global_plans/<id>/resume_execution` API to continue pending tasks.
 

--- a/react_frontend/index.html
+++ b/react_frontend/index.html
@@ -2,7 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="color-scheme" content="dark" />
   <title>OrchestrAI React Dashboard</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://unpkg.com/vis-network@9.1.2/dist/vis-network.min.css" />
   <link rel="stylesheet" href="style.css" />
 </head>

--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -1,27 +1,45 @@
+:root {
+  --bg: #1e1e1e;
+  --sidebar-bg: #27272a;
+  --card-bg: #323236;
+  --border: #444;
+  --text: #e5e7eb;
+  --primary: #3b82f6;
+  --primary-hover: #2563eb;
+  --success-bg: #14532d;
+  --success-text: #bbf7d0;
+  --error-bg: #7f1d1d;
+  --error-text: #fecaca;
+}
+
 body {
-  font-family: Arial, sans-serif;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   margin: 0;
   padding: 0;
+  background: var(--bg);
+  color: var(--text);
 }
 
 .sidebar {
   width: 300px;
   float: left;
   padding: 10px;
-  border-right: 1px solid #ccc;
+  border-right: 1px solid var(--border);
   height: 100vh;
   box-sizing: border-box;
-  background: #f5f5f5;
+  background: var(--sidebar-bg);
 }
 
 .content {
   margin-left: 320px;
   padding: 10px;
+  background: var(--bg);
+  position: relative;
 }
 
 button {
-  background: #007bff;
-  color: white;
+  background: var(--primary);
+  color: var(--text);
   border: none;
   padding: 0.5rem;
   cursor: pointer;
@@ -29,22 +47,19 @@ button {
 }
 
 button:hover {
-  background: #0056b3;
+  background: var(--primary-hover);
 }
 
 textarea {
   width: 100%;
   box-sizing: border-box;
 }
-.content {
-  position: relative;
-}
 
 .artifact-popup {
   position: fixed;
-  background: white;
-  border: 1px solid #ccc;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  box-shadow: 0 2px 6px rgba(0,0,0,0.6);
   padding: 10px;
   max-width: 400px;
   max-height: 300px;
@@ -69,12 +84,16 @@ textarea {
   top: 10px;
   right: 10px;
   z-index: 5;
+  background: var(--primary);
+  color: var(--text);
 }
 .fullscreen-button {
   position: absolute;
   top: 10px;
   right: 110px;
   z-index: 5;
+  background: var(--primary);
+  color: var(--text);
 }
 
 .agents-table {
@@ -83,25 +102,25 @@ textarea {
   margin-bottom: 1rem;
 }
 .agents-table th, .agents-table td {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
   padding: 0.25rem 0.5rem;
 }
 .agents-table .status-online {
-  background: #d4edda;
-  color: #155724;
+  background: var(--success-bg);
+  color: var(--success-text);
   font-weight: bold;
 }
 .agents-table .status-offline {
-  background: #f8d7da;
-  color: #721c24;
+  background: var(--error-bg);
+  color: var(--error-text);
   font-weight: bold;
 }
 
 .clarification-block {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
   padding: 0.5rem;
   margin-bottom: 1rem;
-  background: #fafafa;
+  background: var(--card-bg);
 }
 .chat-history {
   max-height: 200px;
@@ -113,14 +132,14 @@ textarea {
 }
 
 .plan-info {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
   padding: 0.5rem;
   margin-bottom: 1rem;
-  background: #fafafa;
+  background: var(--card-bg);
 }
 
 .plan-info-failure {
-  color: #721c24;
+  color: var(--error-text);
   font-weight: bold;
 }
 
@@ -130,12 +149,13 @@ textarea {
 }
 
 .plan-stats-table td {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
   padding: 0.25rem 0.5rem;
 }
 
 .plan-stats-table .failed-state td {
-  background: #f8d7da;
+  background: var(--error-bg);
+  color: var(--error-text);
   font-weight: bold;
 }
 
@@ -147,10 +167,10 @@ textarea {
   margin-top: 1rem;
 }
 .message-item {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
   padding: 0.5rem;
   margin-bottom: 0.5rem;
-  background: #fafafa;
+  background: var(--card-bg);
 }
 .message-item pre {
   margin: 0;
@@ -158,5 +178,5 @@ textarea {
 }
 .msg-date {
   font-size: 0.8rem;
-  color: #555;
+  color: #9ca3af;
 }


### PR DESCRIPTION
## Summary
- apply dark theme variables and Inter font in the React dashboard
- include font and dark color scheme in `index.html`
- document the new look in the React frontend README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68496a080a24832dab29bab2384e60c8