### PR TITLE
Fix dark theme for inputs

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -58,6 +58,15 @@ textarea {
   box-sizing: border-box;
 }
 
+textarea,
+select,
+input {
+  background: var(--card-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
 .artifact-popup {
   position: fixed;
   background: var(--card-bg);
@@ -129,6 +138,9 @@ textarea {
   max-height: 200px;
   overflow-y: auto;
   margin-bottom: 0.5rem;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  padding: 0.25rem;
 }
 .chat-item {
   margin-bottom: 0.25rem;


### PR DESCRIPTION
## Summary
- use dark colors for select/textarea/input elements
- ensure clarification chat uses dark background

## Testing
- `pip install -r requirements.txt | tail -n 20`
- `pytest -q` *(fails: protobuf version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_684b49341408832d950720a9c1032898