### PR TITLE
Adjust agent status cards

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -140,15 +140,16 @@ function Graph({
 function AgentStatusBar({ agents, graHealth }) {
   if (!agents?.length && !graHealth) return null;
   const graCard = (
-    <div key="gra" className="agent-card gra-card">
-      <div className="agent-name">GRA Server</div>
-      <div className={graHealth === 'online' ? 'status-online' : 'status-offline'}>
-        {graHealth === 'online' ? '✅ Online' : '⚠️ Offline'}
-      </div>
-      <div className="agent-url">
-        <a href={BACKEND_API_URL} target="_blank" rel="noopener noreferrer">
-          {BACKEND_API_URL}
-        </a>
+    <div
+      key="gra"
+      className="agent-card gra-card"
+      title={`URL: ${BACKEND_API_URL}`}
+    >
+      <div className="agent-header">
+        <div className="agent-name">GRA Server</div>
+        <div className={graHealth === 'online' ? 'status-online' : 'status-offline'}>
+          {graHealth === 'online' ? '✅ Online' : '⚠️ Offline'}
+        </div>
       </div>
     </div>
   );
@@ -160,20 +161,15 @@ function AgentStatusBar({ agents, graHealth }) {
         <div
           key={a.name}
           className="agent-card"
-          title={`Skills: ${(a.skills || []).join(', ')}\nInternal: ${a.internal_url}`}
+          title={`Skills: ${(a.skills || []).join(', ')}\nInternal: ${a.internal_url}${a.public_url ? `\nURL: ${a.public_url}` : ''}`}
         >
-          <div className="agent-name">{a.name.replace('AgentServer', '')}</div>
-          <div className={a.health_status?.includes('Online') ? 'status-online' : 'status-offline'}>
-            {a.health_status || ''}
+          <div className="agent-header">
+            <div className="agent-name">{a.name.replace('AgentServer', '')}</div>
+            <div className={a.health_status?.includes('Online') ? 'status-online' : 'status-offline'}>
+              {a.health_status || ''}
+            </div>
           </div>
           <div className="agent-timestamp">{new Date(a.timestamp).toLocaleString()}</div>
-          {a.public_url && (
-            <div className="agent-url">
-              <a href={a.public_url} target="_blank" rel="noopener noreferrer">
-                {a.public_url}
-              </a>
-            </div>
-          )}
         </div>
       ))}
     </div>

--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -121,6 +121,13 @@ input {
   background: var(--card-bg);
   border-radius: 6px;
   min-width: 160px;
+  font-size: 0.9rem;
+}
+
+.agent-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .gra-card {
@@ -129,7 +136,8 @@ input {
 
 .agent-name {
   font-weight: bold;
-  margin-bottom: 0.25rem;
+  margin: 0;
+  margin-right: 0.25rem;
 }
 
 .agent-timestamp {


### PR DESCRIPTION
## Summary
- clean up agent status cards
- shrink font size for cards and make name & status show inline
- hide URLs and surface them in tooltips

## Testing
- `npm test` *(fails: Missing script)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_684d84ce636c832d8f80c9518b91bae3