### PR TITLE
Add agent usage stats

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -144,6 +144,12 @@ input {
   font-size: 0.8rem;
 }
 
+.agent-stats {
+  display: flex;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+}
+
 .status-online {
   background: var(--success-bg);
   color: var(--success-text);

--- a/src/agents/decomposition_agent/executor.py
+++ b/src/agents/decomposition_agent/executor.py
@@ -5,6 +5,7 @@ import json
 
 from src.shared.base_agent_executor import BaseAgentExecutor
 from .logic import DecompositionAgentLogic
+from .server import AGENT_NAME
 from typing import Dict, Any
 from a2a.types import Artifact, Task
 from a2a.utils import new_text_artifact
@@ -17,7 +18,8 @@ class DecompositionAgentExecutor(BaseAgentExecutor):
         super().__init__(
             agent_logic=specific_agent_logic,
             default_artifact_name="decomposed_execution_plan_structure", # Nom d'artefact mis à jour
-            default_artifact_description="Structure JSON complète du plan d'exécution, incluant contexte global, instructions et tâches décomposées."
+            default_artifact_description="Structure JSON complète du plan d'exécution, incluant contexte global, instructions et tâches décomposées.",
+            agent_name=AGENT_NAME,
         )
         logger.info("DecompositionAgentExecutor initialisé.")
     

--- a/src/agents/development_agent/executor.py
+++ b/src/agents/development_agent/executor.py
@@ -4,6 +4,7 @@ import json # Bien que le résultat soit du code, l'input peut être JSON
 
 from src.shared.base_agent_executor import BaseAgentExecutor
 from .logic import DevelopmentAgentLogic
+from .server import AGENT_NAME
 
 from a2a.types import Artifact, Task
 from a2a.utils import new_text_artifact # Le code sera stocké comme un TextArtifact
@@ -16,7 +17,8 @@ class DevelopmentAgentExecutor(BaseAgentExecutor):
         super().__init__(
             agent_logic=specific_agent_logic,
             default_artifact_name="generated_code",
-            default_artifact_description="Code source généré par l'agent de développement."
+            default_artifact_description="Code source généré par l'agent de développement.",
+            agent_name=AGENT_NAME,
         )
         self.logger = logging.getLogger(f"{__name__}.DevelopmentAgentExecutor")
         self.logger.info("DevelopmentAgentExecutor initialisé.")

--- a/src/agents/evaluator/executor.py
+++ b/src/agents/evaluator/executor.py
@@ -4,6 +4,7 @@ import json # Pour formater la sortie du dictionnaire en JSON pour l&#39;artefac
 
 from src.shared.base_agent_executor import BaseAgentExecutor # Ajustez si nécessaire
 from .logic import EvaluatorAgentLogic # Importe la logique spécifique de ce dossier
+from .server import AGENT_NAME
 
 from a2a.types import Artifact, Task
 from a2a.utils import new_text_artifact # Pour créer l'artefact
@@ -17,10 +18,11 @@ class EvaluatorAgentExecutor(BaseAgentExecutor):
     """
     def __init__(self): # CORRECTION: init -> init
         specific_agent_logic = EvaluatorAgentLogic()
-        super().__init__( # CORRECTION: init -> init
+        super().__init__(
         agent_logic=specific_agent_logic,
         default_artifact_name="evaluation_result",
-        default_artifact_description="Le résultat de l'évaluation du plan."
+        default_artifact_description="Le résultat de l'évaluation du plan.",
+        agent_name=AGENT_NAME,
         )
         # Le logger.info est déjà dans la classe de base init
         # logger.info("EvaluatorAgentExecutor (spécifique) initialisé.")

--- a/src/agents/reformulator/executor.py
+++ b/src/agents/reformulator/executor.py
@@ -17,6 +17,7 @@ from a2a.types import (
 # Ajustez les chemins d'importation si votre structure est différente
 from src.shared.base_agent_executor import BaseAgentExecutor
 from .logic import ReformulatorAgentLogic # Importe la logique spécifique de ce dossier
+from .server import AGENT_NAME
 
 from a2a.types import Artifact, Task # Nécessaire pour l'annotation de type de _create_artifact_from_result
 from a2a.utils import new_text_artifact # Utile pour créer l'artefact
@@ -38,7 +39,8 @@ class ReformulatorAgentExecutor(BaseAgentExecutor):
         super().__init__(
             agent_logic=specific_agent_logic,
             default_artifact_name="reformulated_objective",
-            default_artifact_description="L'objectif après reformulation par l'agent."
+            default_artifact_description="L'objectif après reformulation par l'agent.",
+            agent_name=AGENT_NAME,
         )
         # Le logger.info est déjà dans la classe de base __init__
         # logger.info("ReformulatorAgentExecutor (spécifique) initialisé.")

--- a/src/agents/research_agent/executor.py
+++ b/src/agents/research_agent/executor.py
@@ -4,6 +4,7 @@ import json
 
 from src.shared.base_agent_executor import BaseAgentExecutor
 from .logic import ResearchAgentLogic
+from .server import AGENT_NAME
 
 from a2a.types import Artifact, Task
 from a2a.utils import new_text_artifact
@@ -16,7 +17,8 @@ class ResearchAgentExecutor(BaseAgentExecutor):
         super().__init__(
             agent_logic=specific_agent_logic,
             default_artifact_name="research_analysis_output",
-            default_artifact_description="Résultat de la recherche ou de l'analyse effectuée."
+            default_artifact_description="Résultat de la recherche ou de l'analyse effectuée.",
+            agent_name=AGENT_NAME,
         )
         self.logger = logging.getLogger(f"{__name__}.ResearchAgentExecutor") # Logger d'instance
         self.logger.info("ResearchAgentExecutor initialisé.")

--- a/src/agents/testing_agent/executor.py
+++ b/src/agents/testing_agent/executor.py
@@ -4,6 +4,7 @@ import json
 
 from src.shared.base_agent_executor import BaseAgentExecutor
 from .logic import TestingAgentLogic
+from .server import AGENT_NAME
 
 from a2a.types import Artifact, Task
 from a2a.utils import new_text_artifact # Le rapport de test JSON sera un TextArtifact
@@ -16,7 +17,8 @@ class TestingAgentExecutor(BaseAgentExecutor):
         super().__init__(
             agent_logic=specific_agent_logic,
             default_artifact_name="test_report",
-            default_artifact_description="Rapport de test généré pour un livrable."
+            default_artifact_description="Rapport de test généré pour un livrable.",
+            agent_name=AGENT_NAME,
         )
         self.logger = logging.getLogger(f"{__name__}.TestingAgentExecutor")
         self.logger.info("TestingAgentExecutor initialisé.")

--- a/src/agents/user_interaction_agent/executor.py
+++ b/src/agents/user_interaction_agent/executor.py
@@ -4,6 +4,7 @@ import json
 
 from src.shared.base_agent_executor import BaseAgentExecutor
 from .logic import UserInteractionAgentLogic, ACTION_CLARIFY_OBJECTIVE
+from .server import AGENT_NAME
 
 from a2a.types import Artifact, Task, Message, TaskState, TaskStatus # Ajout de TaskState, TaskStatus
 from a2a.utils import new_text_artifact, new_agent_text_message # Ajout de new_agent_text_message
@@ -31,7 +32,8 @@ class UserInteractionAgentExecutor(BaseAgentExecutor):
         super().__init__(
             agent_logic=specific_agent_logic,
             default_artifact_name="user_interaction_output",
-            default_artifact_description="Résultat de l'interaction avec l'utilisateur."
+            default_artifact_description="Résultat de l'interaction avec l'utilisateur.",
+            agent_name=AGENT_NAME,
         )
         logger.info("UserInteractionAgentExecutor initialisé.")
 

--- a/src/agents/validator/executor.py
+++ b/src/agents/validator/executor.py
@@ -4,6 +4,7 @@ import json
 
 from src.shared.base_agent_executor import BaseAgentExecutor
 from .logic import ValidatorAgentLogic
+from .server import AGENT_NAME
 
 from a2a.types import Artifact, Task, Message, TextPart  # Ajout de Message, TextPart
 from a2a.utils import new_text_artifact
@@ -21,7 +22,8 @@ class ValidatorAgentExecutor(BaseAgentExecutor):
         super().__init__(
             agent_logic=specific_agent_logic,
             default_artifact_name="validation_output",
-            default_artifact_description="Le résultat de la validation du plan."
+            default_artifact_description="Le résultat de la validation du plan.",
+            agent_name=AGENT_NAME,
         )
         logger.info("ValidatorAgentExecutor (spécifique) initialisé.")
 


### PR DESCRIPTION
## Summary
- record agent task counts in `BaseAgentExecutor`
- expose aggregated stats with `/v1/stats/agents`
- fetch and show agent stats in the React dashboard

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'a2a')*

------
https://chatgpt.com/codex/tasks/task_e_684db7201c60832dbedaa92881f64eac