### PR TITLE
Display agent processing stats

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -144,6 +144,29 @@ input {
   font-size: 0.8rem;
 }
 
+.agent-metrics {
+  margin-top: 0.25rem;
+  display: flex;
+  gap: 0.25rem;
+}
+
+.metric-success,
+.metric-fail {
+  font-size: 0.8rem;
+  padding: 0.1rem 0.3rem;
+  border-radius: 4px;
+}
+
+.metric-success {
+  background: var(--success-bg);
+  color: var(--success-text);
+}
+
+.metric-fail {
+  background: var(--error-bg);
+  color: var(--error-text);
+}
+
 .status-online {
   background: var(--success-bg);
   color: var(--success-text);


### PR DESCRIPTION
## Summary
- show per-agent processing stats in React dashboard
- fetch new `/v1/stats/agents` endpoint on load
- render completed/failed task metrics inside agent cards

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx' and others)*

------
https://chatgpt.com/codex/tasks/task_e_684dbc339148832db9f993a2d8ec61ac