### PR TITLE
Improve final artifacts view

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -265,3 +265,11 @@ input {
   font-size: 0.8rem;
   color: #a1a1aa;
 }
+
+.json-viewer summary {
+  cursor: pointer;
+  font-weight: bold;
+}
+.json-viewer {
+  margin-left: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add recursive `FormattedContent` component with JSON collapsing
- display parsed content in graph popups and history view
- style JSON viewer

## Testing
- `pip install -q httpx`
- `pip install -q vertexai`
- `pip install -q a2a-sdk`
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684edaaa96e8832d913eaa60cff2bdfd