### PR TITLE
Improve final artifacts history styling

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -24,10 +24,20 @@ function parseMaybeJson(data) {
 
 function FormattedContent({ data, open }) {
   const value = parseMaybeJson(data);
+  const ref = React.useRef(null);
+
+  React.useEffect(() => {
+    if (ref.current && window.hljs) {
+      ref.current.querySelectorAll('pre code').forEach(block => {
+        window.hljs.highlightElement(block);
+      });
+    }
+  }, [value]);
+
   if (value === null || value === undefined) return <span>{String(value)}</span>;
   if (typeof value === 'string') {
-    if (value.length > 80 || value.includes('\n')) return <pre>{value}</pre>;
-    return <span>{value}</span>;
+    const html = window.DOMPurify.sanitize(window.marked.parse(value));
+    return <div ref={ref} dangerouslySetInnerHTML={{ __html: html }} />;
   }
   if (typeof value === 'number' || typeof value === 'boolean') {
     return <span>{String(value)}</span>;

--- a/react_frontend/index.html
+++ b/react_frontend/index.html
@@ -8,6 +8,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="https://unpkg.com/vis-network@9.1.2/dist/vis-network.min.css" />
+  <link rel="stylesheet" href="https://unpkg.com/highlight.js@11.7.0/styles/github-dark.min.css" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
@@ -18,6 +19,9 @@
   <!-- Use Babel 7 to support modern syntax like optional chaining -->
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
   <script src="https://unpkg.com/vis-network@9.1.2/dist/vis-network.min.js"></script>
+  <script src="https://unpkg.com/marked/marked.min.js"></script>
+  <script src="https://unpkg.com/dompurify@3.0.4/dist/purify.min.js"></script>
+  <script src="https://unpkg.com/highlight.js@11.7.0/lib/common.min.js"></script>
   <script type="text/babel" data-presets="react" data-plugins="proposal-optional-chaining" src="app.jsx"></script>
 </body>
 </html>

--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -254,12 +254,23 @@ input {
 .message-item {
   border: 1px solid var(--border);
   padding: 0.5rem;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.75rem;
   background: var(--card-bg);
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 .message-item pre {
   margin: 0;
   white-space: pre-wrap;
+  padding: 0.5rem;
+  background: #272822;
+  border-radius: 6px;
+  overflow-x: auto;
+}
+.message-item code {
+  background: #272822;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
 }
 .msg-date {
   font-size: 0.8rem;


### PR DESCRIPTION
## Summary
- enhance markdown and code display for deliverables history
- load `marked`, `DOMPurify` and `highlight.js` in the React dashboard
- round message item styling and add syntax highlighting support

## Testing
- `pip install -q httpx`
- `pip install -q a2a-sdk`
- `pip install -q google-cloud-aiplatform`
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f132b17a0832d8d417df38e620339