### PR TITLE
Add environment manager docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **Composable & extensible**: Add new agents/skills anytime—just register with the GRA and they’re orchestrated automatically.
 - **A2A protocol & Google ADK compliant**: Ensures interoperability and future-proofing.
 - **Full audit trail**: Every decision, correction, and outcome is persisted in Firestore for transparency.
+- **Isolated dev environments**: Generated code runs in Kubernetes pods managed by the `EnvironmentManager` for safety (see `docs/environment_manager.md`).
 
 ---
 
@@ -166,6 +167,7 @@ graph LR
 * **Communication Inter-Services** : Protocole A2A (via `src/clients/a2a_api_client.py`).
 * **Front-End** : React, déployé sur Firebase Hosting.
 * **Gestion des Tâches Asynchrones** : `asyncio` utilisé extensivement.
+* **Environment Manager** : création et gestion de pods Kubernetes isolés pour l'exécution du code produit.
 
 ## Prérequis
 
@@ -252,7 +254,8 @@ orchestrai-hackathon-ADK/
 │   ├── clients/
 │   ├── orchestrators/
 │   ├── services/
-│   │   └── gra/
+│   │   ├── gra/
+│   │   └── environment_manager/
 │   └── shared/
 ├── react_frontend/                   # Interface React légère
 ├── deployment.sh                     # Script de déploiement Cloud Run

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,8 +4,10 @@
 - Contient les images et ressources pour la documentation technique.
 - Les diagrammes d'architecture y sont référencés par le README principal.
 - Peut également stocker des captures d'écran de l'interface Streamlit.
+- Voir `environment_manager.md` pour la gestion des environnements isolés.
 
 **English:**
 - Holds images and assets for the technical documentation.
 - Architecture diagrams referenced by the main README live here.
 - May also store screenshots of the Streamlit interface.
+- See `environment_manager.md` for details on isolated environment management.

--- a/docs/environment_manager.md
+++ b/docs/environment_manager.md
@@ -1,0 +1,9 @@
+# Environment Manager
+
+**Français :**
+- Service interne créant des environnements Kubernetes isolés pour exécuter le code généré.
+- Utilisé principalement par l'agent de développement pour écrire des fichiers, lancer des commandes et nettoyer les pods.
+
+**English:**
+- Internal service that creates isolated Kubernetes environments where generated code can run safely.
+- Mainly used by the development agent to write files, run commands and destroy pods when done.

--- a/src/agents/development_agent/README.md
+++ b/src/agents/development_agent/README.md
@@ -4,8 +4,10 @@
 - Réalise les tâches de développement logiciel.
 - Génère ou modifie du code selon le plan.
 - Produit des artefacts de code exécutables.
+- S'appuie sur `EnvironmentManager` pour exécuter le code dans un pod Kubernetes isolé.
 
 **English:**
 - Performs software development tasks.
 - Generates or modifies code according to the plan.
 - Produces runnable code artifacts.
+- Relies on `EnvironmentManager` to run code inside an isolated Kubernetes pod.

--- a/src/services/README.md
+++ b/src/services/README.md
@@ -3,9 +3,11 @@
 **Français :**
 - Services internes complémentaires au cœur multi-agents.
 - Le sous-dossier `gra/` contient le Gestionnaire de Ressources et d'Agents.
+- Le dossier `environment_manager/` fournit des environnements Kubernetes isolés pour le développement.
 - Peut être enrichi avec d'autres services spécifiques.
 
 **English:**
 - Auxiliary services complementing the multi-agent core.
 - The `gra/` subfolder hosts the Resource and Agent Manager.
+- The `environment_manager/` folder offers isolated Kubernetes workspaces for development tasks.
 - Can be extended with other internal services.


### PR DESCRIPTION
## Summary
- document the new `EnvironmentManager`
- reference it in docs and services README
- explain isolated dev environments in the main README
- mention environment manager in the development agent README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684f230ab088832d9e5dd5202e0e331b