### PR TITLE
Enhance React dashboard cards

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -248,12 +248,14 @@ function AgentStatusBar({ agents, graHealth, stats }) {
             </div>
           </div>
           <div className="agent-timestamp">{new Date(a.timestamp).toLocaleString()}</div>
-          {statsMap[a.name] && (
-            <div className="agent-metrics">
-              <span className="metric-success">{statsMap[a.name].tasks_completed || 0}</span>
-              <span className="metric-fail">{statsMap[a.name].tasks_failed || 0}</span>
+          <div className="agent-metrics">
+            <div className="metric-tile success">
+              {statsMap[a.name]?.tasks_completed ?? 0}
             </div>
-          )}
+            <div className="metric-tile fail">
+              {statsMap[a.name]?.tasks_failed ?? 0}
+            </div>
+          </div>
         </div>
       ))}
     </div>
@@ -263,14 +265,29 @@ function AgentStatusBar({ agents, graHealth, stats }) {
 function PlanInfo({ plan, flowRunning, hasFailures }) {
   if (!plan) return null;
   return (
-    <div className="plan-info">
-      <div><strong>Plan ID:</strong> {plan.global_plan_id}</div>
-      <div><strong>Objectif brut:</strong> {plan.raw_objective}</div>
+    <div className="plan-cards">
+      <div className="plan-card">
+        <strong>Plan ID</strong>
+        <div>{plan.global_plan_id}</div>
+      </div>
+      <div className="plan-card">
+        <strong>Objectif brut</strong>
+        <div>{plan.raw_objective}</div>
+      </div>
       {plan.clarified_objective && (
-        <div><strong>Objectif clarifié:</strong> {plan.clarified_objective}</div>
+        <div className="plan-card">
+          <strong>Objectif clarifié</strong>
+          <div>{plan.clarified_objective}</div>
+        </div>
       )}
-      <div><strong>État actuel:</strong> {plan.current_supervisor_state}</div>
-      <div><strong>Flux en cours:</strong> {flowRunning ? '🟢 Oui' : '🏁 Terminé'}</div>
+      <div className="plan-card important">
+        <strong>État actuel</strong>
+        <div>{plan.current_supervisor_state}</div>
+      </div>
+      <div className="plan-card important">
+        <strong>Flux en cours</strong>
+        <div>{flowRunning ? '🟢 Oui' : '🏁 Terminé'}</div>
+      </div>
       {hasFailures && (
         <div className="plan-info-failure">❌ Certaines tâches sont en échec</div>
       )}
@@ -281,20 +298,18 @@ function PlanInfo({ plan, flowRunning, hasFailures }) {
 function PlanStats({ team1Counts, team2Counts }) {
   if (!team1Counts && !team2Counts) return null;
 
-  const renderTable = counts => (
-    <table className="plan-stats-table">
-      <tbody>
-        {Object.entries(counts).map(([state, count]) => {
-          const isFailed = state === 'failed' || state === 'unable_to_complete';
-          return (
-            <tr key={state} className={isFailed ? 'failed-state' : ''}>
-              <td>{state}</td>
-              <td>{count}</td>
-            </tr>
-          );
-        })}
-      </tbody>
-    </table>
+  const renderTiles = counts => (
+    <div className="stats-tiles">
+      {Object.entries(counts).map(([state, count]) => {
+        const failed = state === 'failed' || state === 'unable_to_complete';
+        return (
+          <div key={state} className={`stat-tile ${failed ? 'failed' : ''}`}>
+            <div>{state}</div>
+            <div>{count}</div>
+          </div>
+        );
+      })}
+    </div>
   );
 
   return (
@@ -303,13 +318,13 @@ function PlanStats({ team1Counts, team2Counts }) {
       {team1Counts && (
         <div>
           <strong>TEAM 1</strong>
-          {renderTable(team1Counts)}
+          {renderTiles(team1Counts)}
         </div>
       )}
       {team2Counts && (
         <div>
           <strong>TEAM 2</strong>
-          {renderTable(team2Counts)}
+          {renderTiles(team2Counts)}
         </div>
       )}
     </details>
@@ -427,7 +442,7 @@ function App() {
   React.useEffect(() => {
     fetch(`${BACKEND_API_URL}/v1/stats/agents`)
       .then(res => res.json())
-      .then(data => setAgentsStats(data.stats || []))
+      .then(data => setAgentsStats(data.stats || data || []))
       .catch(err => console.error('Erreur chargement statistiques agents', err));
   }, []);
 

--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -147,22 +147,24 @@ input {
 .agent-metrics {
   margin-top: 0.25rem;
   display: flex;
-  gap: 0.25rem;
+  gap: 0.5rem;
 }
 
-.metric-success,
-.metric-fail {
-  font-size: 0.8rem;
-  padding: 0.1rem 0.3rem;
-  border-radius: 4px;
+.metric-tile {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 0.25rem 0.5rem;
+  text-align: center;
+  min-width: 70px;
 }
 
-.metric-success {
+.metric-tile.success {
   background: var(--success-bg);
   color: var(--success-text);
 }
 
-.metric-fail {
+.metric-tile.fail {
   background: var(--error-bg);
   color: var(--error-text);
 }
@@ -203,16 +205,32 @@ input {
   margin-bottom: 0.25rem;
 }
 
-.plan-info {
-  border: 1px solid var(--border);
-  padding: 0.5rem;
+.plan-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
   margin-bottom: 1rem;
+}
+
+.plan-card {
   background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.75rem;
+  min-width: 160px;
+  flex: 1;
+}
+
+.plan-card.important {
+  background: var(--primary);
+  color: var(--text);
+  font-weight: bold;
 }
 
 .plan-info-failure {
   color: var(--error-text);
   font-weight: bold;
+  margin-top: 0.5rem;
 }
 
 .plan-stats {
@@ -228,17 +246,23 @@ input {
   font-weight: bold;
 }
 
-.plan-stats-table {
-  border-collapse: collapse;
-  margin-bottom: 0.5rem;
+.stats-tiles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
-.plan-stats-table td {
+.stat-tile {
+  background: var(--card-bg);
   border: 1px solid var(--border);
-  padding: 0.25rem 0.5rem;
+  border-radius: 6px;
+  padding: 0.5rem;
+  min-width: 120px;
+  text-align: center;
 }
 
-.plan-stats-table .failed-state td {
+.stat-tile.failed {
   background: var(--error-bg);
   color: var(--error-text);
   font-weight: bold;


### PR DESCRIPTION
## Summary
- show agent metrics for all agents
- display plan information in card layout
- show plan statistics with tile layout
- tweak styling for cards and metric tiles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684f2872ff54832d8a3896145a23272d