### PR TITLE
Improve agent stats display and add loading indicator

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -154,9 +154,10 @@ input {
   background: var(--card-bg);
   border: 1px solid var(--border);
   border-radius: 6px;
-  padding: 0.25rem 0.5rem;
+  padding: 0.15rem 0.3rem;
   text-align: center;
-  min-width: 70px;
+  min-width: 50px;
+  font-size: 0.8rem;
 }
 
 .metric-tile.success {
@@ -307,4 +308,32 @@ input {
 }
 .json-viewer {
   margin-left: 0.5rem;
+}
+
+.loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+}
+
+.spinner {
+  border: 4px solid var(--border);
+  border-top-color: var(--primary);
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }


### PR DESCRIPTION
## Summary
- smaller agent metric tiles for a less obtrusive look
- map agent names to executor stats so metrics are accurate
- show a loading spinner while the dashboard fetches initial data

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'a2a.client')*

------
https://chatgpt.com/codex/tasks/task_e_684f2f435cdc832dae2f97021da4da01