### PR TITLE
Fix plan cards layout

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -221,6 +221,7 @@ input {
   min-width: 160px;
   flex: 1;
   display: flex;
+  flex-direction: row;
   align-items: flex-start;
   gap: 0.5rem;
 }
@@ -228,6 +229,11 @@ input {
 .card-header {
   font-weight: bold;
   min-width: 140px;
+}
+
+.card-content {
+  flex: 1;
+  word-break: break-word;
 }
 
 .stat-card .card-content {


### PR DESCRIPTION
## Summary
- tweak CSS for card content layout to stop truncation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684f3670c018832d97526079de6eaca1