### PR TITLE
Add file browser to React UI

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -376,3 +376,35 @@ input {
     transform: rotate(360deg);
   }
 }
+
+.file-browser {
+  margin-top: 1rem;
+  border: 1px solid var(--border);
+  padding: 0.5rem;
+  background: var(--card-bg);
+}
+.file-browser table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.file-browser th,
+.file-browser td {
+  padding: 0.25rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+.file-browser .clickable-row {
+  cursor: pointer;
+}
+.file-browser .path-bar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+.file-browser .file-actions button {
+  margin-left: 0.5rem;
+}
+.error-message {
+  color: var(--error-text);
+  font-weight: bold;
+}


### PR DESCRIPTION
## Summary
- extend the React dashboard with a FileBrowser component
- allow configuring an environment ID in the sidebar
- show environment files and download/upload capabilities
- add basic styles for the new component

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_684f47929bb8832d8f802d2482051856