### PR TITLE
Reload FileBrowser on plan change

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -399,7 +399,7 @@ function FinalArtifactsHistory({ nodes }) {
   );
 }
 
-function FileBrowser({ environmentId }) {
+function FileBrowser({ environmentId, planId }) {
   const [files, setFiles] = React.useState([]);
   const [currentPath, setCurrentPath] = React.useState('.');
   const [isLoading, setIsLoading] = React.useState(false);
@@ -439,6 +439,11 @@ function FileBrowser({ environmentId }) {
   React.useEffect(() => {
     fetchFiles(currentPath);
   }, [fetchFiles, currentPath]);
+
+  React.useEffect(() => {
+    setCurrentPath('.');
+    fetchFiles('.');
+  }, [environmentId, planId]);
 
   const handleDirectoryClick = name => {
     const newPath = currentPath === '.' ? name : `${currentPath}/${name}`;
@@ -989,7 +994,7 @@ function App() {
         )}
         {team2NodesMap && <FinalArtifactsHistory nodes={team2NodesMap} />}
         {activeEnvironmentId && (
-          <FileBrowser environmentId={activeEnvironmentId} />
+          <FileBrowser key={selectedPlanId} planId={selectedPlanId} environmentId={activeEnvironmentId} />
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- reload the file browser when the selected global plan changes

## Testing
- `pytest -q`
- `pytest tests/unit/test_decomposition_logic.py -q`


------
https://chatgpt.com/codex/tasks/task_e_684f49f357d4832db4f83d7e00c5e260