### PR TITLE
Fix auto reload for plan environment

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -668,6 +668,17 @@ function App() {
     return () => clearInterval(id);
   }, [autoRefresh, selectedPlanId]);
 
+  React.useEffect(() => {
+    // Met à jour automatiquement l'environmentId lorsque les détails du plan
+    // sont chargés ou changent. Le FileBrowser utilise cet ID pour se
+    // synchroniser avec l'environnement créé pour TEAM 2.
+    if (planDetails && planDetails.team2_execution_plan_id) {
+      setActiveEnvironmentId(planDetails.team2_execution_plan_id);
+    } else {
+      setActiveEnvironmentId(null);
+    }
+  }, [planDetails?.team2_execution_plan_id]);
+
   function refreshPlanDetails(planId) {
     fetch(`${BACKEND_API_URL}/v1/global_plans/${planId}`)
       .then(res => res.json())


### PR DESCRIPTION
## Summary
- update React frontend to sync environment ID with the selected plan's execution data

## Testing
- `PYTHONPATH=./ pytest tests/unit/test_decomposition_logic.py -q`
- `PYTHONPATH=./ pytest -q` *(fails: ModuleNotFoundError: No module named 'a2a')*

------
https://chatgpt.com/codex/tasks/task_e_684fb9934508832da26629712a239c34