### PR TITLE
Improve artifact history display

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -328,6 +328,13 @@ input {
 .messages-history {
   margin-top: 1rem;
 }
+.artifact-section {
+  margin-bottom: 1rem;
+}
+.artifact-section h5 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1rem;
+}
 .message-item {
   border: 1px solid var(--border);
   padding: 0.5rem;


### PR DESCRIPTION
## Summary
- group final artifacts by type on React dashboard
- style grouped sections for artifacts

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fea0a8b34832db0d07aa1355c1344