### PR TITLE
Fix React hook order in frontend

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -209,7 +209,6 @@ function Graph({
 }
 
 function AgentStatusBar({ agents, graHealth, stats }) {
-  if (!agents?.length && !graHealth) return null;
   const statsMap = React.useMemo(() => {
     const map = {};
     (stats || []).forEach(s => {
@@ -217,6 +216,7 @@ function AgentStatusBar({ agents, graHealth, stats }) {
     });
     return map;
   }, [stats]);
+  if (!agents?.length && !graHealth) return null;
   const graCard = (
     <div
       key="gra"
@@ -394,8 +394,6 @@ function FinalArtifactsHistory({ nodes }) {
     });
   }, [nodes]);
 
-  if (!items.length) return null;
-
   const grouped = React.useMemo(() => {
     const sections = { task_def: [], plan: [], result: [], other: [] };
     items.forEach(it => {
@@ -403,6 +401,8 @@ function FinalArtifactsHistory({ nodes }) {
     });
     return sections;
   }, [items]);
+
+  if (!items.length) return null;
 
   const typeLabels = {
     task_def: 'Définition de tâches',


### PR DESCRIPTION
## Summary
- fix rules-of-hooks error in FinalArtifactsHistory
- avoid conditional hook usage in AgentStatusBar

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684ffc1cf398832db05d2d5c51b60f0d