### PR TITLE
Update Team2 graph colors and legend

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -428,3 +428,31 @@ input {
   color: var(--error-text);
   font-weight: bold;
 }
+
+.graph-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.85rem;
+}
+
+.legend-color,
+.legend-border {
+  width: 14px;
+  height: 14px;
+  display: inline-block;
+  border: 1px solid var(--border);
+  box-sizing: border-box;
+}
+
+.legend-border {
+  background: transparent;
+  border-width: 3px;
+}


### PR DESCRIPTION
## Summary
- adjust Team2 graph coloring: task type colors fill the node and border color reflects task state
- add legend explaining Team2 color codes

## Testing
- `pip install -r requirements.txt` *(fails: dependency conflict protobuf)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx)*

------
https://chatgpt.com/codex/tasks/task_e_684ffe583f78832da08406a48449d55d