### PR TITLE
Fix Team1 graph colors

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -779,7 +779,11 @@ function App() {
 
       const nodeData = { id, label: (info.objective || id).slice(0, 35) };
       if (isTeam1) {
-        nodeData.color = bgColor;
+        let team1Color = '#d3d3d3';
+        if (state === 'completed') team1Color = '#d4edda';
+        else if (state === 'failed' || state === 'unable_to_complete') team1Color = '#f8d7da';
+        else if (state === 'working') team1Color = '#fff3cd';
+        nodeData.color = team1Color;
       } else {
         nodeData.color = { background: bgColor, border: borderColor };
         nodeData.borderWidth = info.sub_task_ids && info.sub_task_ids.length > 0 ? 3 : 1;


### PR DESCRIPTION
## Summary
- restore state-based colors for Team1 graph nodes so they no longer appear gray

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68502c6cf104832db3655cd3b0d1a581