### PR TITLE
Add retry logic for failed tasks

### DIFF
--- a/react_frontend/README.md
+++ b/react_frontend/README.md
@@ -29,6 +29,7 @@ The interface fetches data from `http://localhost:8000` by default (backend API)
 The interface adopts a modern look inspired by Streamlit with the `Inter` font and dark colours.
 
 The dashboard now exposes a **Reprendre l'exécution** button when a plan TEAM 2 is incomplete. Clicking it calls the `/v1/global_plans/<id>/resume_execution` API to continue pending tasks.
+When failures occur, a **Relancer les tâches échouées** button appears to reset failed tasks via `/v1/global_plans/<id>/retry_failed_tasks`.
 
 ## Node Colours
 

--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -858,6 +858,16 @@ function App() {
       .catch(err => console.error('Erreur reprise execution', err));
   }
 
+  function retryFailedTasks(planId) {
+    if (!planId) return;
+    fetch(`${BACKEND_API_URL}/v1/global_plans/${planId}/retry_failed_tasks`, {
+      method: 'POST'
+    })
+      .then(r => r.json())
+      .then(() => refreshPlanDetails(planId))
+      .catch(err => console.error('Erreur relance taches echouees', err));
+  }
+
 
   function showArtifactForNode(nodeId, isTeam1, coords) {
     const nodeInfo = (isTeam1 ? team1NodesMap : team2NodesMap)?.[nodeId];
@@ -1043,6 +1053,11 @@ function App() {
               <button onClick={() => resumeExecution(planDetails.global_plan_id)}>
                 Reprendre l'exécution TEAM 2
               </button>
+              {hasFailures && (
+                <button style={{ marginLeft: '1rem' }} onClick={() => retryFailedTasks(planDetails.global_plan_id)}>
+                  Relancer les tâches échouées
+                </button>
+              )}
             </div>
           )}
         {planDetails?.current_supervisor_state === 'CLARIFICATION_PENDING_USER_INPUT' && (

--- a/src/orchestrators/global_supervisor_logic.py
+++ b/src/orchestrators/global_supervisor_logic.py
@@ -600,6 +600,68 @@ class GlobalSupervisorLogic:
             "global_plan_id": global_plan_id,
             "current_supervisor_state": new_state,
         }
+
+    async def retry_team2_failed_tasks(self, global_plan_id: str) -> Dict[str, Any]:
+        """Relance uniquement les tâches TEAM 2 en échec pour un plan global."""
+        current_plan = await self._load_global_plan_state(global_plan_id)
+        if not current_plan:
+            return {
+                "status": "error",
+                "message": f"Plan global '{global_plan_id}' non trouvé.",
+                "global_plan_id": global_plan_id,
+            }
+
+        exec_plan_id = current_plan.get("team2_execution_plan_id")
+        if not exec_plan_id:
+            return {
+                "status": "error",
+                "message": "Aucune exécution TEAM 2 associée à ce plan.",
+                "global_plan_id": global_plan_id,
+            }
+
+        team1_plan_id = current_plan.get("team1_plan_id")
+        if not team1_plan_id:
+            return {
+                "status": "error",
+                "message": "team1_plan_id manquant pour relance TEAM 2.",
+                "global_plan_id": global_plan_id,
+            }
+
+        team1_text = self._get_final_plan_text_from_team1(team1_plan_id)
+        if not team1_text:
+            return {
+                "status": "error",
+                "message": "Impossible de récupérer le plan TEAM 1 final.",
+                "global_plan_id": global_plan_id,
+            }
+
+        exec_supervisor = ExecutionSupervisorLogic(
+            global_plan_id=global_plan_id,
+            team1_plan_final_text=team1_text,
+            execution_plan_id=exec_plan_id,
+        )
+
+        await exec_supervisor.retry_failed_tasks()
+
+        final_exec_status = exec_supervisor.task_graph.as_dict().get("overall_status", "UNKNOWN")
+
+        new_state = (
+            "TEAM2_EXECUTION_COMPLETED"
+            if final_exec_status.startswith("EXECUTION_COMPLETED")
+            else current_plan.get("current_supervisor_state", "TEAM2_EXECUTION_IN_PROGRESS")
+        )
+
+        await self._save_global_plan_state(global_plan_id, {
+            "current_supervisor_state": new_state,
+            "team2_status": final_exec_status,
+        })
+
+        return {
+            "status": "team2_failed_tasks_retried",
+            "message": final_exec_status,
+            "global_plan_id": global_plan_id,
+            "current_supervisor_state": new_state,
+        }
 async def main_test_global_supervisor():
     supervisor = GlobalSupervisorLogic()
     if not supervisor.db:

--- a/src/services/gra/server.py
+++ b/src/services/gra/server.py
@@ -576,6 +576,24 @@ async def resume_team2_execution_endpoint(global_plan_id: str = Path(..., descri
         logger.error(f"[GRA API] Erreur reprise TEAM 2 pour plan '{global_plan_id}': {e}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Erreur interne du serveur: {str(e)}")
 
+
+@app.post("/v1/global_plans/{global_plan_id}/retry_failed_tasks", response_model=GlobalPlanResponse)
+async def retry_team2_failed_tasks_endpoint(global_plan_id: str = Path(..., description="ID du plan global")):
+    """Relance les tâches TEAM 2 en échec pour un plan global."""
+    logger.info(f"[GRA API] Requête de relance des tâches TEAM 2 échouées pour plan '{global_plan_id}'.")
+    try:
+        supervisor = GlobalSupervisorLogic()
+        result = await supervisor.retry_team2_failed_tasks(global_plan_id)
+        return GlobalPlanResponse(**result)
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Plan global '{global_plan_id}' non trouvé.")
+    except Exception as e:
+        logger.error(
+            f"[GRA API] Erreur relance tâches TEAM 2 échouées pour plan '{global_plan_id}': {e}",
+            exc_info=True,
+        )
+        raise HTTPException(status_code=500, detail=f"Erreur interne du serveur: {str(e)}")
+
 @app.get("/v1/stats/team1_agent_tasks_count", response_model=Team1AgentTasksCountResponse)
 async def get_team1_agent_tasks_count_stats():
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import os
+import sys
+
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)

--- a/tests/unit/test_retry_failed_tasks.py
+++ b/tests/unit/test_retry_failed_tasks.py
@@ -1,0 +1,70 @@
+import pytest
+from unittest.mock import AsyncMock
+import sys
+import types
+
+
+@pytest.mark.asyncio
+async def test_retry_failed_tasks_resets_and_calls_continue(monkeypatch):
+    fake_fb = types.ModuleType("firebase_admin")
+    fake_fb.firestore = types.ModuleType("firestore")
+    sys.modules['firebase_admin'] = fake_fb
+    sys.modules['firebase_admin.firestore'] = fake_fb.firestore
+    dummy_fb_init = types.ModuleType("src.shared.firebase_init")
+    dummy_fb_init.db = None
+    def get_firestore_client():
+        return None
+    dummy_fb_init.get_firestore_client = get_firestore_client
+    sys.modules['src.shared.firebase_init'] = dummy_fb_init
+
+    env_mgr_module = types.ModuleType('src.services.environment_manager.environment_manager')
+    class DummyEnvMgr:
+        async def create_isolated_environment(self, environment_id, base_image='python'):
+            return environment_id
+        def destroy_environment(self, environment_id):
+            pass
+    env_mgr_module.EnvironmentManager = DummyEnvMgr
+    sys.modules['src.services.environment_manager.environment_manager'] = env_mgr_module
+
+    from src.orchestrators.execution_supervisor_logic import (
+        ExecutionSupervisorLogic,
+        ExecutionTaskState,
+    )
+
+    class DummyGraph:
+        def __init__(self, execution_plan_id):
+            self.execution_plan_id = execution_plan_id
+            self.nodes = {
+                't1': {'state': ExecutionTaskState.FAILED.value},
+                't2': {'state': ExecutionTaskState.COMPLETED.value},
+            }
+            self.overall_status = 'EXECUTION_COMPLETED_WITH_FAILURES'
+
+        def as_dict(self):
+            return {'nodes': self.nodes, 'overall_status': self.overall_status}
+
+        def update_task_state(self, task_id, state, details=None):
+            self.nodes[task_id]['state'] = state.value
+
+        def set_overall_status(self, status):
+            self.overall_status = status
+
+    monkeypatch.setattr(
+        'src.orchestrators.execution_supervisor_logic.EnvironmentManager',
+        env_mgr_module.EnvironmentManager,
+    )
+    monkeypatch.setattr(
+        'src.orchestrators.execution_supervisor_logic.ExecutionTaskGraph',
+        DummyGraph,
+    )
+
+    logic = ExecutionSupervisorLogic('gp', 'plan', execution_plan_id='exec')
+    dummy_continue = AsyncMock()
+    monkeypatch.setattr(logic, 'continue_execution', dummy_continue)
+
+    await logic.retry_failed_tasks()
+
+    assert logic.task_graph.nodes['t1']['state'] == ExecutionTaskState.PENDING.value
+    assert logic.task_graph.nodes['t2']['state'] == ExecutionTaskState.COMPLETED.value
+    assert logic.task_graph.overall_status == 'RETRYING_FAILED_TASKS'
+    dummy_continue.assert_awaited()


### PR DESCRIPTION
## Summary
- add `/v1/global_plans/{id}/retry_failed_tasks` endpoint in FastAPI server
- expose button in React dashboard to relaunch failed tasks
- document the new feature in `react_frontend/README.md`
- provide unit test for `retry_failed_tasks`

## Testing
- `pip install httpx pytest a2a-sdk==0.2.8 google-cloud-aiplatform pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68502d4880b8832da0f7dd14874977e4