### PR TITLE
Update artifact popup for failed tasks

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -880,17 +880,23 @@ function App() {
     const display = content =>
       setPopup({ x: coords.x, y: coords.y, content, target: isTeam1 ? 'team1' : 'team2' });
 
-    if (isTeam1) {
+  if (isTeam1) {
       display(parseMaybeJson(nodeInfo.artifact_ref));
-    } else {
+  } else {
       const artifact = nodeInfo.output_artifact_ref;
       if (artifact) {
         fetch(`${BACKEND_API_URL}/artifacts/${artifact}`)
           .then(r => r.json())
-          .then(d => display(parseMaybeJson(d.content)));
+          .then(d => display(parseMaybeJson(d.content)))
+          .catch(() => {
+            if (nodeInfo.state === 'failed')
+              display(nodeInfo.result_summary || 'Échec sans détail');
+          });
+      } else if (nodeInfo.state === 'failed') {
+        display(nodeInfo.result_summary || 'Échec sans détail');
       }
-    }
   }
+}
 
   function ClarificationSection({ plan }) {
     const [answer, setAnswer] = React.useState('');


### PR DESCRIPTION
## Summary
- show a task's failure summary in the graph when no artifact is available

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68503db86160832d9d4d04e7f04200cf