### PR TITLE
Auto select new plan in React UI

### DIFF
--- a/react_frontend/README.md
+++ b/react_frontend/README.md
@@ -30,6 +30,7 @@ The interface adopts a modern look inspired by Streamlit with the `Inter` font a
 
 The dashboard now exposes a **Reprendre l'exécution** button when a plan TEAM 2 is incomplete. Clicking it calls the `/v1/global_plans/<id>/resume_execution` API to continue pending tasks.
 When failures occur, a **Relancer les tâches échouées** button appears to reset failed tasks via `/v1/global_plans/<id>/retry_failed_tasks`.
+When you start a new plan from the sidebar, it is now automatically selected so its details refresh immediately.
 
 ## Node Colours
 

--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -842,11 +842,15 @@ function App() {
       body: JSON.stringify({ objective: newObjective, user_id: 'react_frontend' })
     })
       .then(r => r.json())
-      .then(() => {
+      .then(data => {
+        const newId = data.global_plan_id;
         setNewObjective('');
         return fetch(`${BACKEND_API_URL}/v1/global_plans_summary`)
           .then(res => res.json())
-          .then(data => setPlans(data));
+          .then(plansData => {
+            setPlans(plansData);
+            if (newId) setSelectedPlanId(newId);
+          });
       })
       .catch(err => console.error('Erreur soumission plan', err))
       .finally(() => setPlanSubmitting(false));


### PR DESCRIPTION
## Summary
- auto select the newly created plan in React frontend
- document the automatic selection behavior

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685166587210832d9422363fc601078b