### PR TITLE
Improve environment management

### DIFF
--- a/docs/environment_manager.md
+++ b/docs/environment_manager.md
@@ -1,3 +1,5 @@
 # Environment Manager
 
 Internal service that creates isolated Kubernetes environments where generated code can run safely. It is mainly used by the development agent to write files, run commands and clean up pods once execution is finished.
+
+The manager stores environment metadata in the `kubernetes_environments` Firestore collection. When no dedicated environment is found for a plan, a fallback environment identified by `exec_default` can be used. A helper script `scripts/create_fallback_environment.py` is provided to create this fallback pod.

--- a/scripts/create_fallback_environment.py
+++ b/scripts/create_fallback_environment.py
@@ -1,0 +1,18 @@
+import asyncio
+import logging
+from src.services.environment_manager.environment_manager import EnvironmentManager, FALLBACK_ENV_ID
+
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+async def main():
+    manager = EnvironmentManager()
+    env_id = FALLBACK_ENV_ID
+    logging.info(f"Creating fallback environment '{env_id}' if needed...")
+    created = await manager.create_isolated_environment(env_id)
+    if created:
+        logging.info(f"Fallback environment '{created}' ready. Verify with kubectl or /health endpoint.")
+    else:
+        logging.error("Failed to create fallback environment.")
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/src/orchestrators/global_supervisor_logic.py
+++ b/src/orchestrators/global_supervisor_logic.py
@@ -168,7 +168,7 @@ class GlobalSupervisorLogic:
             logger.error("[GlobalSupervisor] Impossible de créer un environnement isolé, EnvironmentManager non disponible.")
             await self._save_global_plan_state(global_plan_id, {"current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR, "error_message": "EnvironmentManager not available"})
             return {"status": "error", "message": "EnvironmentManager not available", "global_plan_id": global_plan_id}
-        self.plan_environment_id = await self.environment_manager.create_isolated_environment(global_plan_id)
+        self.plan_environment_id = await self.environment_manager.get_environment_or_fallback(global_plan_id)
         plan_data["environment_id"] = self.plan_environment_id
         if self.plan_environment_id:
             await self._save_global_plan_state(global_plan_id, {"environment_id": self.plan_environment_id})

--- a/tests/test_development_agent_curl.sh
+++ b/tests/test_development_agent_curl.sh
@@ -32,6 +32,10 @@ if [ ! -f "$PAYLOAD_FILE" ]; then
     exit 1
 fi
 
+# Extraction de l'environment_id utilisé dans le payload pour information
+ENV_ID=$(jq -r '.params.message.parts[0].text | fromjson | .environment_id' "$PAYLOAD_FILE")
+echo "Environnement utilisé: ${ENV_ID}"
+
 RESPONSE=$(curl -X POST "${AGENT_URL}" \
      -H "Authorization: Bearer ${ID_TOKEN}" \
      -H "Content-Type: application/json" \


### PR DESCRIPTION
## Summary
- normalize environment_id handling in EnvironmentManager
- create helper to fallback to a default environment
- ensure DevelopmentAgent creates or reuses environment via EnvironmentManager
- fallback environment retrieval in supervisors
- add script to create fallback environment
- extend development agent curl test script
- document fallback environment

## Testing
- `python -m py_compile scripts/create_fallback_environment.py src/agents/development_agent/executor.py src/services/environment_manager/environment_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_685284bb7288832d915544e7cdbe1aad