### PR TITLE
Fix A2A task polling

### DIFF
--- a/src/clients/a2a_api_client.py
+++ b/src/clients/a2a_api_client.py
@@ -36,13 +36,16 @@ class GoogleIDTokenAuth(httpx.Auth):
     """
     Classe d'authentification pour httpx qui injecte un Google ID Token.
     """
+
     def __init__(self):
         try:
             self._creds, _ = google.auth.default()
             self._auth_request = GoogleAuthRequest()
         except google.auth.exceptions.DefaultCredentialsError:
             self._creds = None
-            logger.warning("Auth: Impossible d'obtenir les credentials Google. Les requêtes ne seront pas authentifiées. (Normal en local)")
+            logger.warning(
+                "Auth: Impossible d'obtenir les credentials Google. Les requêtes ne seront pas authentifiées. (Normal en local)"
+            )
 
     def auth_flow(self, request: httpx.Request):
         if not self._creds:
@@ -52,9 +55,14 @@ class GoogleIDTokenAuth(httpx.Auth):
             audience = f"{request.url.scheme}://{request.url.host}"
             token = id_token.fetch_id_token(self._auth_request, audience)
             request.headers["Authorization"] = f"Bearer {token}"
-            logger.debug(f"Jeton d'authentification ajouté pour l'audience : {audience}")
+            logger.debug(
+                f"Jeton d'authentification ajouté pour l'audience : {audience}"
+            )
         except Exception as e:
-            logger.error(f"Erreur lors de la récupération du jeton d'authentification Google : {e}", exc_info=True)
+            logger.error(
+                f"Erreur lors de la récupération du jeton d'authentification Google : {e}",
+                exc_info=True,
+            )
         yield request
 
 
@@ -69,74 +77,111 @@ def _create_agent_input_message(
     return Message(
         messageId=str(uuid4()),
         role="user",
-        parts=[
-            TextPart(text=input_text)
-        ],
+        parts=[TextPart(text=input_text)],
         contextId=context_id,
         taskId=task_id,
     )
-    
+
 
 async def call_a2a_agent(
     agent_url: str,
     input_text: str,
     initial_context_id: Optional[str] = None,
     max_retries: int = 30,
-    retry_delay: int = 5
+    retry_delay: int = 5,
 ) -> Optional[Task]:
     """
     Appelle un agent A2A, lui envoie un message texte, et attend sa complétion.
     Gère maintenant l'authentification de service-à-service.
     """
-    logger.info(f"Appel à l'agent A2A à l'URL: {agent_url} avec l'entrée: '{input_text}'")
+    logger.info(
+        f"Appel à l'agent A2A à l'URL: {agent_url} avec l'entrée: '{input_text}'"
+    )
 
     async with httpx.AsyncClient(
-        auth=GoogleIDTokenAuth(), 
-        timeout=30.0,
-        http2=False
+        auth=GoogleIDTokenAuth(), timeout=30.0, http2=False
     ) as http_client:
         try:
             a2a_client = await A2AClient.get_client_from_agent_card_url(
-                httpx_client=http_client,
-                base_url=agent_url
+                httpx_client=http_client, base_url=agent_url
             )
-            logger.info(f"Connecté à l'agent: {a2a_client.card.name if hasattr(a2a_client, 'card') and a2a_client.card else agent_url}")
+            logger.info(
+                f"Connecté à l'agent: {a2a_client.card.name if hasattr(a2a_client, 'card') and a2a_client.card else agent_url}"
+            )
         except Exception as e:
-            logger.error(f"Impossible de se connecter à l'agent {agent_url} ou d'obtenir sa carte: {e}", exc_info=True)
+            logger.error(
+                f"Impossible de se connecter à l'agent {agent_url} ou d'obtenir sa carte: {e}",
+                exc_info=True,
+            )
             return None
 
-        message_payload = _create_agent_input_message(input_text, context_id=initial_context_id)
+        message_payload = _create_agent_input_message(
+            input_text, context_id=initial_context_id
+        )
         send_params = MessageSendParams(message=message_payload)
         send_request = SendMessageRequest(id=str(uuid4()), params=send_params)
 
         task_id: Optional[str] = None
         context_id_for_task: Optional[str] = None
+        created_task: Optional[Task] = None
         try:
             for attempt in range(max_retries):
                 try:
                     send_response = await a2a_client.send_message(request=send_request)
-                    
-                    if hasattr(send_response, 'root') and hasattr(send_response.root, 'result') and isinstance(send_response.root.result, Task):
+
+                    if (
+                        hasattr(send_response, "root")
+                        and hasattr(send_response.root, "result")
+                        and isinstance(send_response.root.result, Task)
+                    ):
                         created_task = send_response.root.result
                         task_id = created_task.id
                         context_id_for_task = created_task.contextId
-                        logger.info(f"Message envoyé. Tâche ID={task_id}, ContextID={context_id_for_task}, Statut initial={created_task.status.state}")
-                        return send_response  # ✅ Succès : on sort
+                        logger.info(
+                            f"Message envoyé. Tâche ID={task_id}, ContextID={context_id_for_task}, Statut initial={created_task.status.state}"
+                        )
+                        if created_task.status.state not in [
+                            TaskState.submitted,
+                            TaskState.working,
+                        ]:
+                            logger.info(
+                                f"Tâche {task_id} retournée directement avec l'état final {created_task.status.state}."
+                            )
+                            return created_task
+                        break
                     else:
-                        error_content = send_response.model_dump_json(indent=2) if hasattr(send_response, 'model_dump_json') else str(send_response)
-                        logger.error(f"Réponse inattendue de send_message à {agent_url}: {error_content}")
+                        error_content = (
+                            send_response.model_dump_json(indent=2)
+                            if hasattr(send_response, "model_dump_json")
+                            else str(send_response)
+                        )
+                        logger.error(
+                            f"Réponse inattendue de send_message à {agent_url}: {error_content}"
+                        )
                         return None
-                
-                except (A2AClientHTTPError, A2AClientJSONError, httpx.RequestError) as e:
-                    logger.error(f"Erreur réseau ou JSON lors de l'envoi du message à {agent_url}: {e}", exc_info=True)
-                    
+
+                except (
+                    A2AClientHTTPError,
+                    A2AClientJSONError,
+                    httpx.RequestError,
+                ) as e:
+                    logger.error(
+                        f"Erreur réseau ou JSON lors de l'envoi du message à {agent_url}: {e}",
+                        exc_info=True,
+                    )
+
                 except Exception as e:
-                    logger.error(f"Erreur inattendue lors de l'envoi du message à {agent_url}: {e}", exc_info=True)
-                
+                    logger.error(
+                        f"Erreur inattendue lors de l'envoi du message à {agent_url}: {e}",
+                        exc_info=True,
+                    )
+
                 # Si on arrive ici : on va retry si pas au dernier tour
                 if attempt < max_retries - 1:
-                    delay = 2 ** attempt
-                    logger.warning(f"A2A call failed on attempt {attempt + 1}, retrying in {delay} seconds...")
+                    delay = 2**attempt
+                    logger.warning(
+                        f"A2A call failed on attempt {attempt + 1}, retrying in {delay} seconds..."
+                    )
                     await asyncio.sleep(delay)
                 else:
                     logger.error(f"A2A call failed after {max_retries} attempts.")
@@ -145,40 +190,75 @@ async def call_a2a_agent(
             logger.error(f"Erreur fatale dans le retry loop: {fatal_e}", exc_info=True)
             return None
 
-
         if not task_id or not context_id_for_task:
-            logger.error(f"Aucun task_id ou context_id valide retourné par send_message pour l'agent {agent_url}.")
+            logger.error(
+                f"Aucun task_id ou context_id valide retourné par send_message pour l'agent {agent_url}."
+            )
             return None
 
-        logger.info(f"Sondage de la tâche {task_id} (contexte {context_id_for_task}) pour l'agent {agent_url}...")
+        logger.info(
+            f"Sondage de la tâche {task_id} (contexte {context_id_for_task}) pour l'agent {agent_url}..."
+        )
         final_task_result: Optional[Task] = None
+        last_task: Optional[Task] = created_task
         for attempt in range(max_retries):
             try:
                 await asyncio.sleep(retry_delay)
-                get_task_params = TaskQueryParams(id=task_id, context_id=context_id_for_task)
-                get_task_request = GetTaskRequest(id=str(uuid4()), params=get_task_params)
+                get_task_params = TaskQueryParams(id=task_id)
+                get_task_request = GetTaskRequest(
+                    id=str(uuid4()), params=get_task_params
+                )
 
                 get_task_response = await a2a_client.get_task(request=get_task_request)
 
-                if hasattr(get_task_response, 'root') and hasattr(get_task_response.root, 'result') and isinstance(get_task_response.root.result, Task):
+                if (
+                    hasattr(get_task_response, "root")
+                    and hasattr(get_task_response.root, "result")
+                    and isinstance(get_task_response.root.result, Task)
+                ):
                     current_task = get_task_response.root.result
-                    logger.info(f"Agent {agent_url} - Tâche {task_id} - Essai {attempt + 1} - Statut: {current_task.status.state}")
-                    
+                    logger.info(
+                        f"Agent {agent_url} - Tâche {task_id} - Essai {attempt + 1} - Statut: {current_task.status.state}"
+                    )
+
                     # --- CORRECTION DE LA CONDITION DE SORTIE DE BOUCLE ---
                     # On ne vérifie que les états 'en cours' valides.
-                    if current_task.status.state not in [TaskState.submitted, TaskState.working]:
+                    last_task = current_task
+                    if current_task.status.state not in [
+                        TaskState.submitted,
+                        TaskState.working,
+                    ]:
                         final_task_result = current_task
                         break
                 else:
-                    error_content_get = get_task_response.model_dump_json(indent=2) if hasattr(get_task_response, 'model_dump_json') else str(get_task_response)
-                    logger.warning(f"Réponse inattendue de get_task pour l'agent {agent_url} (essai {attempt + 1}): {error_content_get}")
+                    error_content_get = (
+                        get_task_response.model_dump_json(indent=2)
+                        if hasattr(get_task_response, "model_dump_json")
+                        else str(get_task_response)
+                    )
+                    logger.warning(
+                        f"Réponse inattendue de get_task pour l'agent {agent_url} (essai {attempt + 1}): {error_content_get}"
+                    )
 
             except Exception as e:
-                logger.error(f"Erreur lors de la récupération de la tâche {task_id} de l'agent {agent_url} (essai {attempt + 1}): {e}", exc_info=True)
-        
-        if final_task_result:
-            logger.info(f"Résultat final obtenu pour la tâche {task_id} de l'agent {agent_url}: Statut={final_task_result.status.state}")
-        else:
-            logger.error(f"La tâche {task_id} de l'agent {agent_url} n'a pas atteint un état final après {max_retries} tentatives.")
+                logger.error(
+                    f"Erreur lors de la récupération de la tâche {task_id} de l'agent {agent_url} (essai {attempt + 1}): {e}",
+                    exc_info=True,
+                )
 
-        return final_task_result
+        if final_task_result:
+            logger.info(
+                f"Résultat final obtenu pour la tâche {task_id} de l'agent {agent_url}: Statut={final_task_result.status.state}"
+            )
+            return final_task_result
+
+        if last_task:
+            logger.error(
+                f"La tâche {task_id} de l'agent {agent_url} n'a pas atteint un état final après {max_retries} tentatives. Dernier statut: {last_task.status.state}"
+            )
+            return last_task
+
+        logger.error(
+            f"La tâche {task_id} de l'agent {agent_url} n'a pas pu être récupérée."
+        )
+        return None


### PR DESCRIPTION
## Summary
- improve polling logic to return a Task when send_message already finished
- track last polled task so we return its status if no final state is reached
- remove unused `context_id` from GetTask request

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: kubernetes, vertexai)*

------
https://chatgpt.com/codex/tasks/task_e_6853b3130eac832daa9d11f01d3a7bdb