### PR TITLE
Fix file manager environment linking

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -325,6 +325,12 @@ function PlanInfo({ plan, flowRunning, hasFailures, team1Counts, team2Counts }) 
         <div className="card-header">Plan ID</div>
         <div className="card-content">{plan.global_plan_id}</div>
       </div>
+      {plan.environment_id && (
+        <div className="plan-card">
+          <div className="card-header">Environment ID</div>
+          <div className="card-content">{plan.environment_id}</div>
+        </div>
+      )}
       <div className="plan-card">
         <div className="card-header">Raw Objective</div>
         <div className="card-content">{plan.raw_objective}</div>
@@ -754,8 +760,14 @@ function App() {
   }, [autoRefresh, selectedPlanId, refreshPlanDetails]);
   
   React.useEffect(() => {
-    if (planDetails && planDetails.team2_execution_plan_id) setActiveEnvironmentId(planDetails.team2_execution_plan_id);
-    else setActiveEnvironmentId(null);
+    if (planDetails) {
+      const envId = planDetails.environment_id ||
+        (planDetails.global_plan_id ? `exec-${planDetails.global_plan_id}` : null);
+      if (envId) setActiveEnvironmentId(envId);
+      else setActiveEnvironmentId(null);
+    } else {
+      setActiveEnvironmentId(null);
+    }
   }, [planDetails]);
 
   // --- 3. FONCTIONS MEMOIZED et HANDLERS ---


### PR DESCRIPTION
## Summary
- expose `environment_id` in GRA API global plan details and summaries
- normalize environment ids in file operation endpoints
- show environment identifier in React plan info
- detect environment from plan details to drive file browser

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: 'kubernetes', 'httpx', 'vertexai')*

------
https://chatgpt.com/codex/tasks/task_e_68554b31b6c0832da85a83edd3907abf