### PR TITLE
Fix file manager environment linking

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -325,6 +325,12 @@ function PlanInfo({ plan, flowRunning, hasFailures, team1Counts, team2Counts }) 
         <div className="card-header">Plan ID</div>
         <div className="card-content">{plan.global_plan_id}</div>
       </div>
+      {plan.environment_id && (
+        <div className="plan-card">
+          <div className="card-header">Environment ID</div>
+          <div className="card-content">{plan.environment_id}</div>
+        </div>
+      )}
       <div className="plan-card">
         <div className="card-header">Raw Objective</div>
         <div className="card-content">{plan.raw_objective}</div>
@@ -754,8 +760,14 @@ function App() {
   }, [autoRefresh, selectedPlanId, refreshPlanDetails]);
   
   React.useEffect(() => {
-    if (planDetails && planDetails.team2_execution_plan_id) setActiveEnvironmentId(planDetails.team2_execution_plan_id);
-    else setActiveEnvironmentId(null);
+    if (planDetails) {
+      const envId = planDetails.environment_id ||
+        (planDetails.global_plan_id ? `exec-${planDetails.global_plan_id}` : null);
+      if (envId) setActiveEnvironmentId(envId);
+      else setActiveEnvironmentId(null);
+    } else {
+      setActiveEnvironmentId(null);
+    }
   }, [planDetails]);
 
   // --- 3. FONCTIONS MEMOIZED et HANDLERS ---

--- a/src/services/environment_manager/environment_manager.py
+++ b/src/services/environment_manager/environment_manager.py
@@ -120,6 +120,9 @@ class EnvironmentManager:
                 raise RuntimeError(f"Pod '{pod_name}' does not exist (404).")
             else:
                 raise
+        except Exception as e:
+            logger.error(f"Connection error while verifying pod '{pod_name}': {e}", exc_info=True)
+            raise RuntimeError(f"Failed to connect to Kubernetes API for pod '{pod_name}'.")
 
     async def _load_existing_environment_details(self, environment_id: str):
         """Tente de charger les détails d'un environnement depuis Firestore et K8s API."""


### PR DESCRIPTION
## Summary
- expose `environment_id` in GRA API global plan details and summaries
- normalize environment ids in file operation endpoints
- show environment identifier in React plan info
- detect environment from plan details to drive file browser
- catch Kubernetes connection errors for file routes

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: 'firebase_admin', 'a2a', 'vertexai')*

------
https://chatgpt.com/codex/tasks/task_e_68554b31b6c0832da85a83edd3907abf