### PR TITLE
Add orchestrator status reporting

### DIFF
--- a/src/orchestrators/execution_supervisor_logic.py
+++ b/src/orchestrators/execution_supervisor_logic.py
@@ -2,6 +2,8 @@ import logging
 import uuid
 import asyncio
 from typing import Optional, Dict, Any, List
+import time
+import os
 import httpx
 import json
 
@@ -9,22 +11,31 @@ from src.shared.execution_task_graph_management import (
     ExecutionTaskGraph,
     ExecutionTaskNode,
     ExecutionTaskState,
-    ExecutionTaskType
+    ExecutionTaskType,
 )
 from src.shared.service_discovery import get_gra_base_url
 from src.clients.a2a_api_client import call_a2a_agent
-from a2a.types import Artifact as A2ATypeArtifact 
+from a2a.types import Artifact as A2ATypeArtifact
 
 from src.agents.testing_agent.logic import AGENT_SKILL_SOFTWARE_TESTING
 from src.agents.development_agent.logic import AGENT_SKILL_CODING_PYTHON
 from src.agents.decomposition_agent.logic import AGENT_SKILL_DECOMPOSE_EXECUTION_PLAN
 
 from src.services.environment_manager.environment_manager import EnvironmentManager
+from src.shared.agent_state import AgentOperationalState
+
 GLOBAL_PLAN_COLLECTION = "global_plans"
 logger = logging.getLogger(__name__)
 
+
 class ExecutionSupervisorLogic:
-    def __init__(self, global_plan_id: str, team1_plan_final_text: str, execution_plan_id: Optional[str] = None, plan_environment_id: Optional[str] = None):
+    def __init__(
+        self,
+        global_plan_id: str,
+        team1_plan_final_text: str,
+        execution_plan_id: Optional[str] = None,
+        plan_environment_id: Optional[str] = None,
+    ):
         """Initialise le superviseur d'exécution.
 
         Parameters
@@ -40,84 +51,179 @@ class ExecutionSupervisorLogic:
         self.team1_plan_final_text = team1_plan_final_text
         self._local_to_global_id_map_for_plan: Dict[str, str] = {}
 
-        self.execution_plan_id = execution_plan_id or f"exec_{self.global_plan_id}_{uuid.uuid4().hex[:8]}"
+        self.execution_plan_id = (
+            execution_plan_id or f"exec_{self.global_plan_id}_{uuid.uuid4().hex[:8]}"
+        )
         self.task_graph = ExecutionTaskGraph(execution_plan_id=self.execution_plan_id)
-        
+
         self._gra_base_url: Optional[str] = None
-        self.logger = logging.getLogger(f"{__name__}.ExecutionSupervisorLogic.{self.execution_plan_id}")
+        self.logger = logging.getLogger(
+            f"{__name__}.ExecutionSupervisorLogic.{self.execution_plan_id}"
+        )
         if not self.logger.hasHandlers() and not self.logger.propagate:
             if not logging.getLogger().hasHandlers():
-                logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-        self.logger.info(f"ExecutionSupervisorLogic initialisé pour global_plan '{global_plan_id}'. Execution plan ID: '{self.execution_plan_id}'")
+                logging.basicConfig(
+                    level=logging.INFO,
+                    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+                )
+        self.logger.info(
+            f"ExecutionSupervisorLogic initialisé pour global_plan '{global_plan_id}'. Execution plan ID: '{self.execution_plan_id}'"
+        )
         self.environment_manager = EnvironmentManager()
         self.plan_environment_id = plan_environment_id
 
+        # --- Operational status tracking ---
+        self.operational_state: AgentOperationalState = AgentOperationalState.IDLE
+        self.status_detail: str | None = None
+        self.last_activity_time: float = time.time()
+        self.gra_url: Optional[str] = None
+
+    def get_status(self) -> Dict[str, Any]:
+        return {
+            "state": self.operational_state.value,
+            "detail": self.status_detail,
+            "last_activity_time": self.last_activity_time,
+            "execution_plan_id": self.execution_plan_id,
+            "global_plan_id": self.global_plan_id,
+        }
+
+    async def _notify_gra_of_status_change(self):
+        if not self.gra_url:
+            self.gra_url = os.environ.get("GRA_PUBLIC_URL") or await get_gra_base_url()
+        if not self.gra_url:
+            self.logger.warning(
+                f"[{self.execution_plan_id}] GRA_PUBLIC_URL non configuré et découverte impossible."
+            )
+            return
+        status_payload = self.get_status()
+        status_payload["name"] = os.environ.get("AGENT_NAME", self.__class__.__name__)
+        try:
+            async with httpx.AsyncClient() as client:
+                await client.post(
+                    f"{self.gra_url}/agent_status_update",
+                    json=status_payload,
+                    timeout=5.0,
+                )
+            self.logger.debug(
+                f"[{self.execution_plan_id}] Statut notifié au GRA: {status_payload}"
+            )
+        except Exception as e:
+            self.logger.error(
+                f"[{self.execution_plan_id}] Échec de la notification au GRA: {e}"
+            )
+
+    async def _update_status(self, state: AgentOperationalState, detail: str):
+        self.operational_state = state
+        self.status_detail = detail
+        self.last_activity_time = time.time()
+        await self._notify_gra_of_status_change()
 
     async def initialize_and_decompose_plan(self):
         """
         Tâche initiale : faire décomposer le plan textuel de TEAM 1 en ExecutionTaskGraph.
         """
-        self.logger.info(f"[{self.execution_plan_id}] Initialisation et décomposition du plan de TEAM 1.")
+        self.logger.info(
+            f"[{self.execution_plan_id}] Initialisation et décomposition du plan de TEAM 1."
+        )
+        await self._update_status(
+            AgentOperationalState.WORKING, "Décomposition du plan"
+        )
         self.task_graph.set_overall_status("INITIALIZING")
-        self._local_to_global_id_map_for_plan.clear() 
+        self._local_to_global_id_map_for_plan.clear()
 
         decomposition_task_id = f"decompose_{self.execution_plan_id}"
         decomposition_task = ExecutionTaskNode(
             task_id=decomposition_task_id,
             objective="Décomposer le plan textuel de TEAM 1 en tâches d'exécution structurées.",
             task_type=ExecutionTaskType.DECOMPOSITION,
-            assigned_agent_type=AGENT_SKILL_DECOMPOSE_EXECUTION_PLAN
+            assigned_agent_type=AGENT_SKILL_DECOMPOSE_EXECUTION_PLAN,
         )
         self.task_graph.add_task(decomposition_task, is_root=True)
-        self.task_graph.update_task_state(decomposition_task_id, ExecutionTaskState.READY, "Prêt pour décomposition initiale.")
-        
-        self.logger.info(f"[{self.execution_plan_id}] Tâche de décomposition '{decomposition_task_id}' créée et marquée READY.")
+        self.task_graph.update_task_state(
+            decomposition_task_id,
+            ExecutionTaskState.READY,
+            "Prêt pour décomposition initiale.",
+        )
+
+        self.logger.info(
+            f"[{self.execution_plan_id}] Tâche de décomposition '{decomposition_task_id}' créée et marquée READY."
+        )
         self.task_graph.set_overall_status("PENDING_DECOMPOSITION")
+        await self._update_status(
+            AgentOperationalState.IDLE, "Décomposition initiale prête"
+        )
 
     async def _ensure_gra_url(self):
         if not self._gra_base_url:
             self._gra_base_url = await get_gra_base_url()
             if not self._gra_base_url:
-                msg = f"[{self.execution_plan_id}] Impossible de découvrir l'URL du GRA."
+                msg = (
+                    f"[{self.execution_plan_id}] Impossible de découvrir l'URL du GRA."
+                )
                 self.logger.error(msg)
                 raise ConnectionError(msg)
         return self._gra_base_url
+
     async def _get_agent_details_from_gra(self, skill: str) -> Optional[Dict[str, str]]:
         gra_url = await self._ensure_gra_url()
         agent_details = None
         try:
             async with httpx.AsyncClient() as client:
-                self.logger.info(f"[{self.execution_plan_id}] Demande au GRA ({gra_url}) un agent avec la compétence: '{skill}'")
-                response = await client.get(f"{gra_url}/agents", params={"skill": skill}, timeout=10.0)
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Demande au GRA ({gra_url}) un agent avec la compétence: '{skill}'"
+                )
+                response = await client.get(
+                    f"{gra_url}/agents", params={"skill": skill}, timeout=10.0
+                )
                 response.raise_for_status()
                 data = response.json()
-                
-                agent_data = data[0] if isinstance(data, list) and len(data) > 0 else None
-                
+
+                agent_data = (
+                    data[0] if isinstance(data, list) and len(data) > 0 else None
+                )
+
                 if not agent_data:
-                    self.logger.warning(f"[{self.execution_plan_id}] Aucun agent retourné par le GRA pour la compétence '{skill}'.")
+                    self.logger.warning(
+                        f"[{self.execution_plan_id}] Aucun agent retourné par le GRA pour la compétence '{skill}'."
+                    )
                     return None
 
                 if agent_data.get("internal_url") and agent_data.get("name"):
-                    agent_details = {"url": agent_data["internal_url"], "name": agent_data["name"]}
-                    self.logger.info(f"[{self.execution_plan_id}] Détails pour '{skill}' obtenus du GRA: {agent_details}")
+                    agent_details = {
+                        "url": agent_data["internal_url"],
+                        "name": agent_data["name"],
+                    }
+                    self.logger.info(
+                        f"[{self.execution_plan_id}] Détails pour '{skill}' obtenus du GRA: {agent_details}"
+                    )
                 else:
-                    self.logger.error(f"[{self.execution_plan_id}] Données incomplètes du GRA pour '{skill}'. La réponse ne contient pas 'internal_url' ou 'name'. Réponse reçue: {agent_data}")
-        
+                    self.logger.error(
+                        f"[{self.execution_plan_id}] Données incomplètes du GRA pour '{skill}'. La réponse ne contient pas 'internal_url' ou 'name'. Réponse reçue: {agent_data}"
+                    )
+
         except httpx.HTTPStatusError as e:
-            self.logger.error(f"[{self.execution_plan_id}] Erreur HTTP ({e.response.status_code}) en contactant le GRA pour '{skill}' à {e.request.url}: {e.response.text}")
+            self.logger.error(
+                f"[{self.execution_plan_id}] Erreur HTTP ({e.response.status_code}) en contactant le GRA pour '{skill}' à {e.request.url}: {e.response.text}"
+            )
         except httpx.RequestError as e:
-            self.logger.error(f"[{self.execution_plan_id}] Erreur de requête en contactant le GRA pour '{skill}': {e}")
+            self.logger.error(
+                f"[{self.execution_plan_id}] Erreur de requête en contactant le GRA pour '{skill}': {e}"
+            )
         except Exception as e:
-            self.logger.error(f"[{self.execution_plan_id}] Erreur inattendue en contactant le GRA pour '{skill}': {e}", exc_info=True)
-            
+            self.logger.error(
+                f"[{self.execution_plan_id}] Erreur inattendue en contactant le GRA pour '{skill}': {e}",
+                exc_info=True,
+            )
+
         return agent_details
 
-    async def _store_a2a_artifact_in_gra(self, 
-                                          a2a_artifact_to_store: A2ATypeArtifact, 
-                                          a2a_task_id: str, 
-                                          a2a_context_id: str, 
-                                          producing_agent_name: str) -> Optional[str]:
+    async def _store_a2a_artifact_in_gra(
+        self,
+        a2a_artifact_to_store: A2ATypeArtifact,
+        a2a_task_id: str,
+        a2a_context_id: str,
+        producing_agent_name: str,
+    ) -> Optional[str]:
         gra_url = await self._ensure_gra_url()
         if not gra_url:
             return None
@@ -125,71 +231,104 @@ class ExecutionSupervisorLogic:
         content_for_gra: Optional[str | Dict[str, Any]] = None
         if a2a_artifact_to_store.parts:
             first_part = a2a_artifact_to_store.parts[0]
-            if hasattr(first_part, 'root') and hasattr(first_part.root, 'text'):
-                 content_for_gra = first_part.root.text
-            elif hasattr(first_part, 'text'):
-                 content_for_gra = first_part.text
+            if hasattr(first_part, "root") and hasattr(first_part.root, "text"):
+                content_for_gra = first_part.root.text
+            elif hasattr(first_part, "text"):
+                content_for_gra = first_part.text
 
         if content_for_gra is None:
-            self.logger.warning(f"[{self.execution_plan_id}] L'artefact A2A (ID local: {a2a_artifact_to_store.artifactId}) n'a pas de contenu textuel extractible pour le stockage GRA.")
+            self.logger.warning(
+                f"[{self.execution_plan_id}] L'artefact A2A (ID local: {a2a_artifact_to_store.artifactId}) n'a pas de contenu textuel extractible pour le stockage GRA."
+            )
             return None
 
         gra_artifact_payload = {
             "task_id": a2a_task_id,
             "context_id": a2a_context_id,
             "agent_name": producing_agent_name,
-            "content": content_for_gra 
+            "content": content_for_gra,
         }
-        
+
         try:
             async with httpx.AsyncClient() as client:
-                self.logger.info(f"[{self.execution_plan_id}] Stockage de l'artefact (produit par {producing_agent_name} pour tâche {a2a_task_id}) via GRA: {gra_url}/artifacts")
-                self.logger.debug(f"Payload pour GRA /artifacts: {json.dumps(gra_artifact_payload, indent=2)}")
-                response = await client.post(f"{gra_url}/artifacts", json=gra_artifact_payload, timeout=10.0)
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Stockage de l'artefact (produit par {producing_agent_name} pour tâche {a2a_task_id}) via GRA: {gra_url}/artifacts"
+                )
+                self.logger.debug(
+                    f"Payload pour GRA /artifacts: {json.dumps(gra_artifact_payload, indent=2)}"
+                )
+                response = await client.post(
+                    f"{gra_url}/artifacts", json=gra_artifact_payload, timeout=10.0
+                )
                 response.raise_for_status()
                 response_data = response.json()
                 gra_artifact_id = response_data.get("artifact_id")
                 if gra_artifact_id:
-                    self.logger.info(f"[{self.execution_plan_id}] Artefact stocké avec succès dans GRA. ID GRA: {gra_artifact_id} (ID A2A local était: {a2a_artifact_to_store.artifactId})")
+                    self.logger.info(
+                        f"[{self.execution_plan_id}] Artefact stocké avec succès dans GRA. ID GRA: {gra_artifact_id} (ID A2A local était: {a2a_artifact_to_store.artifactId})"
+                    )
                     return gra_artifact_id
                 else:
-                    self.logger.error(f"[{self.execution_plan_id}] Le GRA n'a pas retourné d'artifact_id après stockage. Réponse: {response_data}")
+                    self.logger.error(
+                        f"[{self.execution_plan_id}] Le GRA n'a pas retourné d'artifact_id après stockage. Réponse: {response_data}"
+                    )
                     return None
         except Exception as e:
-            self.logger.error(f"[{self.execution_plan_id}] Erreur lors du stockage de l'artefact via GRA: {e}", exc_info=True)
+            self.logger.error(
+                f"[{self.execution_plan_id}] Erreur lors du stockage de l'artefact via GRA: {e}",
+                exc_info=True,
+            )
             return None
 
     async def _fetch_artifact_content(self, gra_artifact_id: str) -> Optional[str]:
         if not gra_artifact_id:
-            self.logger.warning(f"[{self.execution_plan_id}] ID d'artefact GRA vide fourni pour récupération.")
+            self.logger.warning(
+                f"[{self.execution_plan_id}] ID d'artefact GRA vide fourni pour récupération."
+            )
             return None
         try:
             gra_url = await self._ensure_gra_url()
             async with httpx.AsyncClient() as client:
-                self.logger.info(f"[{self.execution_plan_id}] Récupération de l'artefact GRA ID '{gra_artifact_id}'.")
-                response = await client.get(f"{gra_url}/artifacts/{gra_artifact_id}", timeout=10.0)
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Récupération de l'artefact GRA ID '{gra_artifact_id}'."
+                )
+                response = await client.get(
+                    f"{gra_url}/artifacts/{gra_artifact_id}", timeout=10.0
+                )
                 response.raise_for_status()
                 artifact_data_from_gra = response.json()
-                
+
                 content = artifact_data_from_gra.get("content")
                 if isinstance(content, str):
                     return content
                 elif isinstance(content, dict):
                     return json.dumps(content, ensure_ascii=False)
                 else:
-                    self.logger.warning(f"[{self.execution_plan_id}] Artefact GRA ID '{gra_artifact_id}' a un contenu de type inattendu: {type(content)}.")
+                    self.logger.warning(
+                        f"[{self.execution_plan_id}] Artefact GRA ID '{gra_artifact_id}' a un contenu de type inattendu: {type(content)}."
+                    )
                     return str(content)
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
-                self.logger.error(f"[{self.execution_plan_id}] Artefact GRA ID '{gra_artifact_id}' non trouvé dans le GRA (404).")
+                self.logger.error(
+                    f"[{self.execution_plan_id}] Artefact GRA ID '{gra_artifact_id}' non trouvé dans le GRA (404)."
+                )
             else:
-                self.logger.error(f"[{self.execution_plan_id}] Erreur HTTP lors de la récupération de l'artefact GRA ID '{gra_artifact_id}': {e}", exc_info=True)
+                self.logger.error(
+                    f"[{self.execution_plan_id}] Erreur HTTP lors de la récupération de l'artefact GRA ID '{gra_artifact_id}': {e}",
+                    exc_info=True,
+                )
             return None
         except Exception as e:
-            self.logger.error(f"[{self.execution_plan_id}] Erreur lors de la récupération du contenu de l'artefact GRA ID '{gra_artifact_id}': {e}", exc_info=True)
+            self.logger.error(
+                f"[{self.execution_plan_id}] Erreur lors de la récupération du contenu de l'artefact GRA ID '{gra_artifact_id}': {e}",
+                exc_info=True,
+            )
             return None
 
-    async def _prepare_input_for_execution_agent(self, task_node: ExecutionTaskNode) -> str:
+    async def _prepare_input_for_execution_agent(
+        self, task_node: ExecutionTaskNode
+    ) -> str:
         input_payload = {
             "objective": task_node.objective,
             "local_instructions": task_node.meta.get("local_instructions", []),
@@ -197,40 +336,68 @@ class ExecutionSupervisorLogic:
             "task_id": task_node.id,
             "execution_plan_id": self.execution_plan_id,
             "task_type": task_node.task_type.value,
-            "assigned_skill": task_node.assigned_agent_type
+            "assigned_skill": task_node.assigned_agent_type,
         }
         if self.plan_environment_id:
             input_payload["environment_id"] = self.plan_environment_id
-            self.logger.info(f"[{self.execution_plan_id}] Passing environment_id '{self.plan_environment_id}' to task {task_node.id}")
+            self.logger.info(
+                f"[{self.execution_plan_id}] Passing environment_id '{self.plan_environment_id}' to task {task_node.id}"
+            )
         else:
-            self.logger.warning(f"[{self.execution_plan_id}] No plan_environment_id set for task {task_node.id}. Agent might fail if it needs an environment.")
+            self.logger.warning(
+                f"[{self.execution_plan_id}] No plan_environment_id set for task {task_node.id}. Agent might fail if it needs an environment."
+            )
 
         if task_node.task_type == ExecutionTaskType.EXPLORATORY:
             available_skills = await self._get_all_available_execution_skills_from_gra()
             input_payload["available_execution_skills"] = available_skills
-            self.logger.debug(f"[{self.execution_plan_id}] Ajout de {len(available_skills)} compétences disponibles à l'input pour la tâche exploratoire {task_node.id}")
+            self.logger.debug(
+                f"[{self.execution_plan_id}] Ajout de {len(available_skills)} compétences disponibles à l'input pour la tâche exploratoire {task_node.id}"
+            )
 
-        if task_node.assigned_agent_type == AGENT_SKILL_SOFTWARE_TESTING and task_node.dependencies:
-            self.logger.debug(f"[{self.execution_plan_id}] Tâche de test {task_node.id}. Recherche du livrable parmi les dépendances: {task_node.dependencies}")
+        if (
+            task_node.assigned_agent_type == AGENT_SKILL_SOFTWARE_TESTING
+            and task_node.dependencies
+        ):
+            self.logger.debug(
+                f"[{self.execution_plan_id}] Tâche de test {task_node.id}. Recherche du livrable parmi les dépendances: {task_node.dependencies}"
+            )
             found_deliverable = False
             for dep_id in task_node.dependencies:
                 dep_task_node = self.task_graph.get_task(dep_id)
-                if dep_task_node and dep_task_node.assigned_agent_type == AGENT_SKILL_CODING_PYTHON: 
-                    if dep_task_node.output_artifact_ref: 
-                        self.logger.info(f"[{self.execution_plan_id}] Tâche de test {task_node.id} dépend de {dep_id} (code). Récupération de l'artefact GRA ID: {dep_task_node.output_artifact_ref}.")
-                        deliverable_content = await self._fetch_artifact_content(dep_task_node.output_artifact_ref)
+                if (
+                    dep_task_node
+                    and dep_task_node.assigned_agent_type == AGENT_SKILL_CODING_PYTHON
+                ):
+                    if dep_task_node.output_artifact_ref:
+                        self.logger.info(
+                            f"[{self.execution_plan_id}] Tâche de test {task_node.id} dépend de {dep_id} (code). Récupération de l'artefact GRA ID: {dep_task_node.output_artifact_ref}."
+                        )
+                        deliverable_content = await self._fetch_artifact_content(
+                            dep_task_node.output_artifact_ref
+                        )
                         if deliverable_content:
                             input_payload["deliverable"] = deliverable_content
-                            self.logger.info(f"[{self.execution_plan_id}] Livrable (code) de {dep_id} (artefact GRA {dep_task_node.output_artifact_ref}) injecté pour test {task_node.id}.")
+                            self.logger.info(
+                                f"[{self.execution_plan_id}] Livrable (code) de {dep_id} (artefact GRA {dep_task_node.output_artifact_ref}) injecté pour test {task_node.id}."
+                            )
                             found_deliverable = True
                         else:
-                            self.logger.warning(f"[{self.execution_plan_id}] Contenu du livrable de {dep_id} (artefact GRA {dep_task_node.output_artifact_ref}) non récupérable pour test {task_node.id}.")
-                            input_payload["deliverable"] = f"// ERREUR: Contenu du livrable (artefact GRA {dep_task_node.output_artifact_ref}) non récupérable."
-                        break 
+                            self.logger.warning(
+                                f"[{self.execution_plan_id}] Contenu du livrable de {dep_id} (artefact GRA {dep_task_node.output_artifact_ref}) non récupérable pour test {task_node.id}."
+                            )
+                            input_payload["deliverable"] = (
+                                f"// ERREUR: Contenu du livrable (artefact GRA {dep_task_node.output_artifact_ref}) non récupérable."
+                            )
+                        break
             if not found_deliverable:
-                 self.logger.warning(f"[{self.execution_plan_id}] Aucun livrable de code trouvé via dépendances pour tâche de test {task_node.id}.")
-                 input_payload["deliverable"] = "// ATTENTION: Aucun livrable de code trouvé dans les dépendances directes."
-        
+                self.logger.warning(
+                    f"[{self.execution_plan_id}] Aucun livrable de code trouvé via dépendances pour tâche de test {task_node.id}."
+                )
+                input_payload["deliverable"] = (
+                    "// ATTENTION: Aucun livrable de code trouvé dans les dépendances directes."
+                )
+
         if task_node.input_data_refs:
             input_payload["input_artifacts_content"] = {}
             self.logger.debug(
@@ -256,264 +423,493 @@ class ExecutionSupervisorLogic:
                         f"[{self.execution_plan_id}] Référence d'entrée '{ref_name}' utilise directement l'ID d'artefact {ref_value}."
                     )
 
-                artifact_content = await self._fetch_artifact_content(resolved_artifact_id)
+                artifact_content = await self._fetch_artifact_content(
+                    resolved_artifact_id
+                )
                 if artifact_content:
-                    input_payload["input_artifacts_content"][ref_name] = artifact_content
+                    input_payload["input_artifacts_content"][
+                        ref_name
+                    ] = artifact_content
                 else:
-                    input_payload["input_artifacts_content"][ref_name] = (
-                        f"// ERREUR: Contenu de l'artefact GRA ID {resolved_artifact_id} non récupérable pour input '{ref_name}'."
-                    )
+                    input_payload["input_artifacts_content"][
+                        ref_name
+                    ] = f"// ERREUR: Contenu de l'artefact GRA ID {resolved_artifact_id} non récupérable pour input '{ref_name}'."
             if not input_payload["input_artifacts_content"]:
                 del input_payload["input_artifacts_content"]
-        
+
         return json.dumps(input_payload, ensure_ascii=False, indent=2)
 
     async def process_plan_execution(self):
-        self.logger.info(f"[{self.execution_plan_id}] Début du cycle de traitement d'exécution.")
+        self.logger.info(
+            f"[{self.execution_plan_id}] Début du cycle de traitement d'exécution."
+        )
+        await self._update_status(AgentOperationalState.WORKING, "Cycle d'exécution")
         current_graph_snapshot_before_ready = self.task_graph.as_dict()
         ready_tasks_nodes = self.task_graph.get_ready_tasks()
 
         if not ready_tasks_nodes:
-            self.logger.info(f"[{self.execution_plan_id}] Aucune tâche d'exécution prête pour ce cycle.")
-            overall_status = current_graph_snapshot_before_ready.get("overall_status", "UNKNOWN")
-            if overall_status.startswith("COMPLETED") or overall_status.startswith("FAILED") or overall_status.startswith("TIMEOUT") or overall_status == "PLAN_DECOMPOSED_EMPTY":
-                 self.logger.info(f"[{self.execution_plan_id}] Plan d'exécution déjà dans un état terminal ou sans tâches enfants: {overall_status}")
-                 return
-            
+            self.logger.info(
+                f"[{self.execution_plan_id}] Aucune tâche d'exécution prête pour ce cycle."
+            )
+            overall_status = current_graph_snapshot_before_ready.get(
+                "overall_status", "UNKNOWN"
+            )
+            if (
+                overall_status.startswith("COMPLETED")
+                or overall_status.startswith("FAILED")
+                or overall_status.startswith("TIMEOUT")
+                or overall_status == "PLAN_DECOMPOSED_EMPTY"
+            ):
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Plan d'exécution déjà dans un état terminal ou sans tâches enfants: {overall_status}"
+                )
+                return
+
             all_nodes_data = current_graph_snapshot_before_ready.get("nodes", {})
             if not all_nodes_data and overall_status == "PENDING_DECOMPOSITION":
-                 self.logger.info(f"[{self.execution_plan_id}] En attente de la tâche de décomposition initiale (graph vide).")
-                 return
+                self.logger.info(
+                    f"[{self.execution_plan_id}] En attente de la tâche de décomposition initiale (graph vide)."
+                )
+                return
 
             non_terminal_tasks_count = 0
             has_failures_in_graph = False
             if all_nodes_data:
                 for _, node_data in all_nodes_data.items():
-                    state = ExecutionTaskState(node_data.get("state", ExecutionTaskState.PENDING))
-                    if state not in [ExecutionTaskState.COMPLETED, ExecutionTaskState.FAILED, ExecutionTaskState.CANCELLED]:
+                    state = ExecutionTaskState(
+                        node_data.get("state", ExecutionTaskState.PENDING)
+                    )
+                    if state not in [
+                        ExecutionTaskState.COMPLETED,
+                        ExecutionTaskState.FAILED,
+                        ExecutionTaskState.CANCELLED,
+                    ]:
                         non_terminal_tasks_count += 1
                     if state == ExecutionTaskState.FAILED:
                         has_failures_in_graph = True
-                
-                if non_terminal_tasks_count == 0: 
-                    final_status = "EXECUTION_COMPLETED_WITH_FAILURES" if has_failures_in_graph else "EXECUTION_COMPLETED_SUCCESSFULLY"
-                    self.logger.info(f"[{self.execution_plan_id}] Toutes les tâches d'exécution sont terminales. Statut: {final_status}")
+
+                if non_terminal_tasks_count == 0:
+                    final_status = (
+                        "EXECUTION_COMPLETED_WITH_FAILURES"
+                        if has_failures_in_graph
+                        else "EXECUTION_COMPLETED_SUCCESSFULLY"
+                    )
+                    self.logger.info(
+                        f"[{self.execution_plan_id}] Toutes les tâches d'exécution sont terminales. Statut: {final_status}"
+                    )
                     self.task_graph.set_overall_status(final_status)
             return
 
         for task_node_from_ready in ready_tasks_nodes:
             task_node = self.task_graph.get_task(task_node_from_ready.id)
             if not task_node:
-                self.logger.warning(f"[{self.execution_plan_id}] Tâche {task_node_from_ready.id} retournée par get_ready_tasks mais non trouvée ensuite. Skipping.")
+                self.logger.warning(
+                    f"[{self.execution_plan_id}] Tâche {task_node_from_ready.id} retournée par get_ready_tasks mais non trouvée ensuite. Skipping."
+                )
                 continue
-            
-            self.logger.debug(f"[{self.execution_plan_id}] Tâche {task_node.id} rechargée, état actuel en DB: {task_node.state.value}")
+
+            self.logger.debug(
+                f"[{self.execution_plan_id}] Tâche {task_node.id} rechargée, état actuel en DB: {task_node.state.value}"
+            )
             if task_node.state != ExecutionTaskState.READY:
-                self.logger.info(f"[{self.execution_plan_id}] Tâche {task_node.id} récupérée avec état '{task_node.state.value}' au lieu de READY. Skipping.")
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Tâche {task_node.id} récupérée avec état '{task_node.state.value}' au lieu de READY. Skipping."
+                )
                 continue
 
             current_overall_status = self.task_graph.as_dict().get("overall_status")
-            if task_node.task_type == ExecutionTaskType.DECOMPOSITION and \
-               current_overall_status not in ["INITIALIZING", "PENDING_DECOMPOSITION"]:
-                self.logger.info(f"[{self.execution_plan_id}] Tâche de décomposition {task_node.id} READY, mais statut global ('{current_overall_status}') indique traitement déjà fait. Forcing COMPLETED.")
-                self.task_graph.update_task_state(task_node.id, ExecutionTaskState.COMPLETED, "Forçage COMPLETED (décomposition déjà faite).")
+            if (
+                task_node.task_type == ExecutionTaskType.DECOMPOSITION
+                and current_overall_status
+                not in ["INITIALIZING", "PENDING_DECOMPOSITION"]
+            ):
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Tâche de décomposition {task_node.id} READY, mais statut global ('{current_overall_status}') indique traitement déjà fait. Forcing COMPLETED."
+                )
+                self.task_graph.update_task_state(
+                    task_node.id,
+                    ExecutionTaskState.COMPLETED,
+                    "Forçage COMPLETED (décomposition déjà faite).",
+                )
                 continue
 
-            self.logger.info(f"[{self.execution_plan_id}] Prise en charge tâche prête: {task_node.id} ('{task_node.objective}'), Type: {task_node.task_type.value}, État: {task_node.state.value}")
-            self.task_graph.update_task_state(task_node.id, ExecutionTaskState.ASSIGNED, "Assignation en cours...")
-            
+            self.logger.info(
+                f"[{self.execution_plan_id}] Prise en charge tâche prête: {task_node.id} ('{task_node.objective}'), Type: {task_node.task_type.value}, État: {task_node.state.value}"
+            )
+            self.task_graph.update_task_state(
+                task_node.id, ExecutionTaskState.ASSIGNED, "Assignation en cours..."
+            )
+
             agent_skill_needed = task_node.assigned_agent_type
             if not agent_skill_needed:
-                self.logger.error(f"[{self.execution_plan_id}] Tâche {task_node.id} sans assigned_agent_type. Passage FAILED.")
-                self.task_graph.update_task_state(task_node.id, ExecutionTaskState.FAILED, "Type d'agent requis non spécifié.")
+                self.logger.error(
+                    f"[{self.execution_plan_id}] Tâche {task_node.id} sans assigned_agent_type. Passage FAILED."
+                )
+                self.task_graph.update_task_state(
+                    task_node.id,
+                    ExecutionTaskState.FAILED,
+                    "Type d'agent requis non spécifié.",
+                )
                 continue
 
             agent_details = await self._get_agent_details_from_gra(agent_skill_needed)
             if not agent_details or not agent_details.get("url"):
-                self.logger.error(f"[{self.execution_plan_id}] Aucun agent pour '{agent_skill_needed}' (tâche {task_node.id}). Remise à READY.")
-                self.task_graph.update_task_state(task_node.id, ExecutionTaskState.READY, f"Agent pour '{agent_skill_needed}' non trouvé, en attente.")
+                self.logger.error(
+                    f"[{self.execution_plan_id}] Aucun agent pour '{agent_skill_needed}' (tâche {task_node.id}). Remise à READY."
+                )
+                self.task_graph.update_task_state(
+                    task_node.id,
+                    ExecutionTaskState.READY,
+                    f"Agent pour '{agent_skill_needed}' non trouvé, en attente.",
+                )
                 continue
-            
-            agent_url = agent_details["url"]
-            agent_name_from_gra = agent_details.get("name", agent_skill_needed) 
 
-            self.task_graph.update_task_state(task_node.id, ExecutionTaskState.WORKING, f"Appel agent {agent_name_from_gra} ({agent_skill_needed}) à {agent_url}.")
-            
+            agent_url = agent_details["url"]
+            agent_name_from_gra = agent_details.get("name", agent_skill_needed)
+
+            self.task_graph.update_task_state(
+                task_node.id,
+                ExecutionTaskState.WORKING,
+                f"Appel agent {agent_name_from_gra} ({agent_skill_needed}) à {agent_url}.",
+            )
+
             input_for_agent_text = ""
             if task_node.task_type == ExecutionTaskType.DECOMPOSITION:
-                all_registered_agents_skills = await self._get_all_available_execution_skills_from_gra()
+                all_registered_agents_skills = (
+                    await self._get_all_available_execution_skills_from_gra()
+                )
                 input_payload_for_decomposition = {
                     "team1_plan_text": self.team1_plan_final_text,
-                    "available_execution_skills": all_registered_agents_skills
+                    "available_execution_skills": all_registered_agents_skills,
                 }
-                input_for_agent_text = json.dumps(input_payload_for_decomposition, ensure_ascii=False)
+                input_for_agent_text = json.dumps(
+                    input_payload_for_decomposition, ensure_ascii=False
+                )
             else:
-                input_for_agent_text = await self._prepare_input_for_execution_agent(task_node)
+                input_for_agent_text = await self._prepare_input_for_execution_agent(
+                    task_node
+                )
 
-            a2a_task_result = await call_a2a_agent(agent_url, input_for_agent_text, self.execution_plan_id)
+            a2a_task_result = await call_a2a_agent(
+                agent_url, input_for_agent_text, self.execution_plan_id
+            )
 
             if a2a_task_result and a2a_task_result.status:
                 a2a_state_val = a2a_task_result.status.state.value
-                gra_persisted_artifact_id: Optional[str] = None 
-                artifact_text_content = None 
+                gra_persisted_artifact_id: Optional[str] = None
+                artifact_text_content = None
 
                 if a2a_task_result.artifacts and len(a2a_task_result.artifacts) > 0:
                     first_a2a_artifact = a2a_task_result.artifacts[0]
                     gra_persisted_artifact_id = await self._store_a2a_artifact_in_gra(
                         first_a2a_artifact,
-                        a2a_task_result.id, 
-                        a2a_task_result.contextId, 
-                        agent_name_from_gra 
+                        a2a_task_result.id,
+                        a2a_task_result.contextId,
+                        agent_name_from_gra,
                     )
                     if first_a2a_artifact.parts:
                         part_cont = first_a2a_artifact.parts[0]
-                        if hasattr(part_cont, 'root') and hasattr(part_cont.root, 'text'): artifact_text_content = part_cont.root.text
-                        elif hasattr(part_cont, 'text'): artifact_text_content = part_cont.text
-                
+                        if hasattr(part_cont, "root") and hasattr(
+                            part_cont.root, "text"
+                        ):
+                            artifact_text_content = part_cont.root.text
+                        elif hasattr(part_cont, "text"):
+                            artifact_text_content = part_cont.text
+
                 if a2a_state_val == "completed":
                     if task_node.task_type == ExecutionTaskType.DECOMPOSITION:
-                        if artifact_text_content: 
+                        if artifact_text_content:
                             try:
-                                decomposed_plan_structure = json.loads(artifact_text_content)
-                                tasks_to_create = decomposed_plan_structure.get("tasks", [])
+                                decomposed_plan_structure = json.loads(
+                                    artifact_text_content
+                                )
+                                tasks_to_create = decomposed_plan_structure.get(
+                                    "tasks", []
+                                )
                                 if isinstance(tasks_to_create, list):
                                     if not tasks_to_create:
-                                        self.task_graph.update_task_state(task_node.id, ExecutionTaskState.COMPLETED, "Décomposition OK, aucune tâche enfant produite.")
-                                        self.task_graph.update_task_output(task_node.id, artifact_ref=gra_persisted_artifact_id) 
-                                        self.task_graph.set_overall_status("PLAN_DECOMPOSED_EMPTY") 
+                                        self.task_graph.update_task_state(
+                                            task_node.id,
+                                            ExecutionTaskState.COMPLETED,
+                                            "Décomposition OK, aucune tâche enfant produite.",
+                                        )
+                                        self.task_graph.update_task_output(
+                                            task_node.id,
+                                            artifact_ref=gra_persisted_artifact_id,
+                                        )
+                                        self.task_graph.set_overall_status(
+                                            "PLAN_DECOMPOSED_EMPTY"
+                                        )
                                     else:
-                                        self.task_graph.update_task_output(task_node.id, artifact_ref=gra_persisted_artifact_id, summary="Plan décomposé.")
-                                        await self._add_and_resolve_decomposed_tasks(tasks_to_create, task_node.id)
-                                        self.task_graph.update_task_state(task_node.id, ExecutionTaskState.COMPLETED, "Décomposition OK, tâches enfants ajoutées.")
-                                        self.task_graph.set_overall_status("PLAN_DECOMPOSED")
+                                        self.task_graph.update_task_output(
+                                            task_node.id,
+                                            artifact_ref=gra_persisted_artifact_id,
+                                            summary="Plan décomposé.",
+                                        )
+                                        await self._add_and_resolve_decomposed_tasks(
+                                            tasks_to_create, task_node.id
+                                        )
+                                        self.task_graph.update_task_state(
+                                            task_node.id,
+                                            ExecutionTaskState.COMPLETED,
+                                            "Décomposition OK, tâches enfants ajoutées.",
+                                        )
+                                        self.task_graph.set_overall_status(
+                                            "PLAN_DECOMPOSED"
+                                        )
                                 else:
-                                    self.task_graph.update_task_state(task_node.id, ExecutionTaskState.FAILED, "Format 'tasks' incorrect dans décomposition.")
-                                    self.task_graph.update_task_output(task_node.id, artifact_ref=gra_persisted_artifact_id) 
+                                    self.task_graph.update_task_state(
+                                        task_node.id,
+                                        ExecutionTaskState.FAILED,
+                                        "Format 'tasks' incorrect dans décomposition.",
+                                    )
+                                    self.task_graph.update_task_output(
+                                        task_node.id,
+                                        artifact_ref=gra_persisted_artifact_id,
+                                    )
                             except json.JSONDecodeError:
-                                self.task_graph.update_task_state(task_node.id, ExecutionTaskState.FAILED, "Artefact décomposition JSON invalide.")
-                                self.task_graph.update_task_output(task_node.id, artifact_ref=gra_persisted_artifact_id)
+                                self.task_graph.update_task_state(
+                                    task_node.id,
+                                    ExecutionTaskState.FAILED,
+                                    "Artefact décomposition JSON invalide.",
+                                )
+                                self.task_graph.update_task_output(
+                                    task_node.id, artifact_ref=gra_persisted_artifact_id
+                                )
                         else:
-                            self.task_graph.update_task_state(task_node.id, ExecutionTaskState.FAILED, "Agent décomposition n'a pas retourné d'artefact textuel.")
-                    
+                            self.task_graph.update_task_state(
+                                task_node.id,
+                                ExecutionTaskState.FAILED,
+                                "Agent décomposition n'a pas retourné d'artefact textuel.",
+                            )
+
                     elif task_node.task_type == ExecutionTaskType.EXPLORATORY:
-                        self.task_graph.update_task_output(task_node.id, artifact_ref=gra_persisted_artifact_id, summary="Exploration terminée (pré-traitement).")
-                        await self._process_completed_exploratory_task(task_node, artifact_text_content)
-                    
+                        self.task_graph.update_task_output(
+                            task_node.id,
+                            artifact_ref=gra_persisted_artifact_id,
+                            summary="Exploration terminée (pré-traitement).",
+                        )
+                        await self._process_completed_exploratory_task(
+                            task_node, artifact_text_content
+                        )
+
                     elif task_node.task_type == ExecutionTaskType.EXECUTABLE:
                         summary = f"Livrable par {agent_name_from_gra}."
-                        if artifact_text_content and len(artifact_text_content) < 100: summary += f" Aperçu: {artifact_text_content[:50]}..."
-                        self.task_graph.update_task_output(task_node.id, artifact_ref=gra_persisted_artifact_id, summary=summary)
-                        self.task_graph.update_task_state(task_node.id, ExecutionTaskState.COMPLETED, "Exécution OK.")
-                        self.logger.info(f"[{self.execution_plan_id}] APPEL update_task_output pour TÂCHE EXECUTABLE {task_node.id}: artifact_ref='{gra_persisted_artifact_id}', summary='{summary}'")
+                        if artifact_text_content and len(artifact_text_content) < 100:
+                            summary += f" Aperçu: {artifact_text_content[:50]}..."
+                        self.task_graph.update_task_output(
+                            task_node.id,
+                            artifact_ref=gra_persisted_artifact_id,
+                            summary=summary,
+                        )
+                        self.task_graph.update_task_state(
+                            task_node.id, ExecutionTaskState.COMPLETED, "Exécution OK."
+                        )
+                        self.logger.info(
+                            f"[{self.execution_plan_id}] APPEL update_task_output pour TÂCHE EXECUTABLE {task_node.id}: artifact_ref='{gra_persisted_artifact_id}', summary='{summary}'"
+                        )
 
+                    else:
+                        self.task_graph.update_task_output(
+                            task_node.id, artifact_ref=gra_persisted_artifact_id
+                        )
+                        self.task_graph.update_task_state(
+                            task_node.id, ExecutionTaskState.COMPLETED, "Tâche traitée."
+                        )
 
-                    
-                    else: 
-                        self.task_graph.update_task_output(task_node.id, artifact_ref=gra_persisted_artifact_id)
-                        self.task_graph.update_task_state(task_node.id, ExecutionTaskState.COMPLETED, "Tâche traitée.")
-                
                 elif a2a_state_val == "failed":
                     error_summary = f"Échec tâche A2A {a2a_task_result.id} pour {task_node.id} (agent {agent_name_from_gra})."
-                    if artifact_text_content: error_summary += f" Détail: {artifact_text_content[:100]}"
-                    self.task_graph.update_task_output(task_node.id, artifact_ref=gra_persisted_artifact_id, summary=error_summary) 
-                    self.task_graph.update_task_state(task_node.id, ExecutionTaskState.FAILED, error_summary)
+                    if artifact_text_content:
+                        error_summary += f" Détail: {artifact_text_content[:100]}"
+                    self.task_graph.update_task_output(
+                        task_node.id,
+                        artifact_ref=gra_persisted_artifact_id,
+                        summary=error_summary,
+                    )
+                    self.task_graph.update_task_state(
+                        task_node.id, ExecutionTaskState.FAILED, error_summary
+                    )
 
-                else: 
-                    unexpected_state_summary = f"État A2A inattendu: {a2a_state_val} pour {task_node.id}."
-                    if artifact_text_content: unexpected_state_summary += f" Artefact: {artifact_text_content[:100]}"
-                    self.task_graph.update_task_output(task_node.id, artifact_ref=gra_persisted_artifact_id, summary=unexpected_state_summary)
-                    self.task_graph.update_task_state(task_node.id, ExecutionTaskState.FAILED, f"État A2A inattendu: {a2a_state_val}")
+                else:
+                    unexpected_state_summary = (
+                        f"État A2A inattendu: {a2a_state_val} pour {task_node.id}."
+                    )
+                    if artifact_text_content:
+                        unexpected_state_summary += (
+                            f" Artefact: {artifact_text_content[:100]}"
+                        )
+                    self.task_graph.update_task_output(
+                        task_node.id,
+                        artifact_ref=gra_persisted_artifact_id,
+                        summary=unexpected_state_summary,
+                    )
+                    self.task_graph.update_task_state(
+                        task_node.id,
+                        ExecutionTaskState.FAILED,
+                        f"État A2A inattendu: {a2a_state_val}",
+                    )
             else:
-                self.task_graph.update_task_state(task_node.id, ExecutionTaskState.FAILED, "Réponse agent A2A invalide/absente.")
-        
-        self.logger.info(f"[{self.execution_plan_id}] Fin du cycle de traitement d'exécution.")
+                self.task_graph.update_task_state(
+                    task_node.id,
+                    ExecutionTaskState.FAILED,
+                    "Réponse agent A2A invalide/absente.",
+                )
 
+        self.logger.info(
+            f"[{self.execution_plan_id}] Fin du cycle de traitement d'exécution."
+        )
+        await self._update_status(AgentOperationalState.IDLE, "Cycle terminé")
 
     async def run_full_execution(self):
         if not self.plan_environment_id:
-            self.logger.warning(f"[{self.execution_plan_id}] No environment_id provided. Retrieving via EnvironmentManager.")
-            self.plan_environment_id = await self.environment_manager.get_environment_or_fallback(self.execution_plan_id)
+            self.logger.warning(
+                f"[{self.execution_plan_id}] No environment_id provided. Retrieving via EnvironmentManager."
+            )
+            self.plan_environment_id = (
+                await self.environment_manager.get_environment_or_fallback(
+                    self.execution_plan_id
+                )
+            )
             if not self.plan_environment_id:
-                self.logger.error(f"[{self.execution_plan_id}] Failed to obtain fallback environment.")
+                self.logger.error(
+                    f"[{self.execution_plan_id}] Failed to obtain fallback environment."
+                )
                 self.task_graph.set_overall_status("FAILED_ENVIRONMENT_CREATION")
                 return
 
+        await self._update_status(
+            AgentOperationalState.WORKING, "Exécution complète du plan"
+        )
+
         await self.initialize_and_decompose_plan()
-        
-        max_cycles = 10 
+
+        max_cycles = 10
         for i in range(max_cycles):
-            self.logger.info(f"\n--- CYCLE D'EXÉCUTION TEAM 2 N°{i+1}/{max_cycles} pour le plan {self.execution_plan_id} ---")
+            self.logger.info(
+                f"\n--- CYCLE D'EXÉCUTION TEAM 2 N°{i+1}/{max_cycles} pour le plan {self.execution_plan_id} ---"
+            )
             await self.process_plan_execution()
 
             current_graph_data = self.task_graph.as_dict()
             all_nodes = current_graph_data.get("nodes", {})
             overall_status = current_graph_data.get("overall_status", "UNKNOWN")
 
-            if overall_status == "EXECUTION_COMPLETED_SUCCESSFULLY" or \
-               overall_status == "EXECUTION_COMPLETED_WITH_FAILURES" or \
-               overall_status.startswith("FAILED") or \
-               overall_status == "TIMEOUT_EXECUTION":
-                self.logger.info(f"[{self.execution_plan_id}] Statut global du plan d'exécution est terminal ({overall_status}). Arrêt de run_full_execution.")
-                break 
+            if (
+                overall_status == "EXECUTION_COMPLETED_SUCCESSFULLY"
+                or overall_status == "EXECUTION_COMPLETED_WITH_FAILURES"
+                or overall_status.startswith("FAILED")
+                or overall_status == "TIMEOUT_EXECUTION"
+            ):
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Statut global du plan d'exécution est terminal ({overall_status}). Arrêt de run_full_execution."
+                )
+                break
 
             if not all_nodes and overall_status == "PENDING_DECOMPOSITION":
-                self.logger.info(f"[{self.execution_plan_id}] En attente de la décomposition initiale. Cycle {i+1}.")
-                await asyncio.sleep(5) 
+                self.logger.info(
+                    f"[{self.execution_plan_id}] En attente de la décomposition initiale. Cycle {i+1}."
+                )
+                await asyncio.sleep(5)
                 continue
 
             non_terminal_tasks = [
-                nid for nid, ndata in all_nodes.items() 
-                if ExecutionTaskState(ndata.get("state", ExecutionTaskState.PENDING)) not in [
-                    ExecutionTaskState.COMPLETED, ExecutionTaskState.FAILED, ExecutionTaskState.CANCELLED
+                nid
+                for nid, ndata in all_nodes.items()
+                if ExecutionTaskState(ndata.get("state", ExecutionTaskState.PENDING))
+                not in [
+                    ExecutionTaskState.COMPLETED,
+                    ExecutionTaskState.FAILED,
+                    ExecutionTaskState.CANCELLED,
                 ]
             ]
 
-            if (overall_status.startswith("PLAN_DECOMPOSED") or overall_status == "PLAN_DECOMPOSED_EMPTY") and not non_terminal_tasks:
-                has_failed_tasks_in_graph = any(ExecutionTaskState(ndata.get("state")) == ExecutionTaskState.FAILED for ndata in all_nodes.values())
-                final_plan_status = "EXECUTION_COMPLETED_WITH_FAILURES" if has_failed_tasks_in_graph else "EXECUTION_COMPLETED_SUCCESSFULLY"
-                self.logger.info(f"[{self.execution_plan_id}] Toutes les tâches d'exécution sont terminales. Fin de l'exécution. Statut: {final_plan_status}")
+            if (
+                overall_status.startswith("PLAN_DECOMPOSED")
+                or overall_status == "PLAN_DECOMPOSED_EMPTY"
+            ) and not non_terminal_tasks:
+                has_failed_tasks_in_graph = any(
+                    ExecutionTaskState(ndata.get("state")) == ExecutionTaskState.FAILED
+                    for ndata in all_nodes.values()
+                )
+                final_plan_status = (
+                    "EXECUTION_COMPLETED_WITH_FAILURES"
+                    if has_failed_tasks_in_graph
+                    else "EXECUTION_COMPLETED_SUCCESSFULLY"
+                )
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Toutes les tâches d'exécution sont terminales. Fin de l'exécution. Statut: {final_plan_status}"
+                )
                 self.task_graph.set_overall_status(final_plan_status)
-                break 
+                break
 
             if i == max_cycles - 1:
-                self.logger.warning(f"[{self.execution_plan_id}] Nombre maximum de cycles d'exécution ({max_cycles}) atteint.")
-                if overall_status not in ["EXECUTION_COMPLETED_SUCCESSFULLY", "EXECUTION_COMPLETED_WITH_FAILURES"]:
+                self.logger.warning(
+                    f"[{self.execution_plan_id}] Nombre maximum de cycles d'exécution ({max_cycles}) atteint."
+                )
+                if overall_status not in [
+                    "EXECUTION_COMPLETED_SUCCESSFULLY",
+                    "EXECUTION_COMPLETED_WITH_FAILURES",
+                ]:
                     self.task_graph.set_overall_status("TIMEOUT_EXECUTION")
-                break 
-            await asyncio.sleep(5)         
+                break
+            await asyncio.sleep(5)
         if self.plan_environment_id:
             self.environment_manager.destroy_environment(self.plan_environment_id)
             self.plan_environment_id = None
-            self.logger.info(f"[{self.execution_plan_id}] Environment '{self.execution_plan_id}' cleaned up.")
-        
+            self.logger.info(
+                f"[{self.execution_plan_id}] Environment '{self.execution_plan_id}' cleaned up."
+            )
+
         final_status = self.task_graph.as_dict().get("overall_status", "UNKNOWN")
-        self.logger.info(f"[{self.execution_plan_id}] Exécution terminée avec le statut: {final_status}")
+        self.logger.info(
+            f"[{self.execution_plan_id}] Exécution terminée avec le statut: {final_status}"
+        )
+        await self._update_status(
+            AgentOperationalState.IDLE, f"Exécution terminée: {final_status}"
+        )
 
     async def continue_execution(self, max_cycles: int = 5):
         """Reprendre un plan existant pour traiter les tâches restantes."""
         if not self.plan_environment_id:
-            self.plan_environment_id = await self.environment_manager.get_environment_or_fallback(self.execution_plan_id)
+            self.plan_environment_id = (
+                await self.environment_manager.get_environment_or_fallback(
+                    self.execution_plan_id
+                )
+            )
             if not self.plan_environment_id:
-                self.logger.error(f"[{self.execution_plan_id}] Failed to recreate/attach dedicated environment for continuation. Aborting.")
+                self.logger.error(
+                    f"[{self.execution_plan_id}] Failed to recreate/attach dedicated environment for continuation. Aborting."
+                )
                 self.task_graph.set_overall_status("FAILED_ENVIRONMENT_RECREATION")
                 return
 
+        await self._update_status(AgentOperationalState.WORKING, "Reprise d'exécution")
+
         for i in range(max_cycles):
-            self.logger.info(f"\n--- CYCLE DE REPRISE N°{i+1}/{max_cycles} pour le plan {self.execution_plan_id} ---")
+            self.logger.info(
+                f"\n--- CYCLE DE REPRISE N°{i+1}/{max_cycles} pour le plan {self.execution_plan_id} ---"
+            )
             await self.process_plan_execution()
 
             snapshot = self.task_graph.as_dict()
             overall_status = snapshot.get("overall_status", "UNKNOWN")
             nodes = snapshot.get("nodes", {})
 
-            if overall_status.startswith("EXECUTION_COMPLETED") or overall_status.startswith("FAILED") or overall_status == "TIMEOUT_EXECUTION":
-                self.logger.info(f"[{self.execution_plan_id}] Plan déjà terminé ({overall_status}). Arrêt de la reprise.")
+            if (
+                overall_status.startswith("EXECUTION_COMPLETED")
+                or overall_status.startswith("FAILED")
+                or overall_status == "TIMEOUT_EXECUTION"
+            ):
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Plan déjà terminé ({overall_status}). Arrêt de la reprise."
+                )
                 break
 
             non_terminal = [
                 nid
                 for nid, ndata in nodes.items()
-                if ExecutionTaskState(ndata.get("state", ExecutionTaskState.PENDING)) not in [
+                if ExecutionTaskState(ndata.get("state", ExecutionTaskState.PENDING))
+                not in [
                     ExecutionTaskState.COMPLETED,
                     ExecutionTaskState.FAILED,
                     ExecutionTaskState.CANCELLED,
@@ -522,25 +918,40 @@ class ExecutionSupervisorLogic:
 
             if not non_terminal:
                 has_failed = any(
-                    ExecutionTaskState(ndata.get("state")) == ExecutionTaskState.FAILED for ndata in nodes.values()
+                    ExecutionTaskState(ndata.get("state")) == ExecutionTaskState.FAILED
+                    for ndata in nodes.values()
                 )
-                final_state = "EXECUTION_COMPLETED_WITH_FAILURES" if has_failed else "EXECUTION_COMPLETED_SUCCESSFULLY"
-                self.logger.info(f"[{self.execution_plan_id}] Toutes les tâches sont terminées. Statut: {final_state}")
+                final_state = (
+                    "EXECUTION_COMPLETED_WITH_FAILURES"
+                    if has_failed
+                    else "EXECUTION_COMPLETED_SUCCESSFULLY"
+                )
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Toutes les tâches sont terminées. Statut: {final_state}"
+                )
                 self.task_graph.set_overall_status(final_state)
                 break
 
             if i == max_cycles - 1:
-                self.logger.warning(f"[{self.execution_plan_id}] Nombre maximum de cycles de reprise atteint.")
+                self.logger.warning(
+                    f"[{self.execution_plan_id}] Nombre maximum de cycles de reprise atteint."
+                )
                 break
 
             await asyncio.sleep(5)
         if self.plan_environment_id:
             self.environment_manager.destroy_environment(self.plan_environment_id)
             self.plan_environment_id = None
-            self.logger.info(f"[{self.execution_plan_id}] Environment '{self.execution_plan_id}' cleaned up after continuation.")
+            self.logger.info(
+                f"[{self.execution_plan_id}] Environment '{self.execution_plan_id}' cleaned up after continuation."
+            )
+        await self._update_status(AgentOperationalState.IDLE, "Reprise terminée")
 
     async def retry_failed_tasks(self, max_cycles: int = 5):
         """Relance uniquement les tâches actuellement en échec."""
+        await self._update_status(
+            AgentOperationalState.WORKING, "Relance des tâches échouées"
+        )
         snapshot = self.task_graph.as_dict()
         nodes = snapshot.get("nodes", {})
         failed_tasks = [
@@ -551,32 +962,51 @@ class ExecutionSupervisorLogic:
         ]
 
         if not failed_tasks:
-            self.logger.info(f"[{self.execution_plan_id}] Aucune tâche en échec à relancer.")
+            self.logger.info(
+                f"[{self.execution_plan_id}] Aucune tâche en échec à relancer."
+            )
         else:
             for task_id in failed_tasks:
-                self.logger.info(f"[{self.execution_plan_id}] Reset état FAILED -> PENDING pour la tâche {task_id}.")
-                self.task_graph.update_task_state(task_id, ExecutionTaskState.PENDING, "Relance demandée.")
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Reset état FAILED -> PENDING pour la tâche {task_id}."
+                )
+                self.task_graph.update_task_state(
+                    task_id, ExecutionTaskState.PENDING, "Relance demandée."
+                )
 
             self.task_graph.set_overall_status("RETRYING_FAILED_TASKS")
 
         await self.continue_execution(max_cycles=max_cycles)
-
+        await self._update_status(AgentOperationalState.IDLE, "Relance terminée")
 
     async def _get_all_available_execution_skills_from_gra(self) -> List[str]:
-        self.logger.info(f"[{self.execution_plan_id}] Récupération des compétences d'exécution disponibles depuis le GRA.")
+        self.logger.info(
+            f"[{self.execution_plan_id}] Récupération des compétences d'exécution disponibles depuis le GRA."
+        )
         gra_url = await self._ensure_gra_url()
         all_skills = set()
         execution_related_skills_keywords = [
-            "coding", "python", "javascript", "java", 
-            "research", "analysis", "synthesis",      
-            "testing", "test_case", 
-            "database_design", "api_design",         
-            "documentation", "document_synthesis",                       
-             "execution_plan_decomposition" 
+            "coding",
+            "python",
+            "javascript",
+            "java",
+            "research",
+            "analysis",
+            "synthesis",
+            "testing",
+            "test_case",
+            "database_design",
+            "api_design",
+            "documentation",
+            "document_synthesis",
+            "execution_plan_decomposition",
         ]
         excluded_skills_for_decomposition_assignment = [
-            "clarify_objective", "reformulation", "evaluation", "validation", 
-            "execution_plan_decomposition" 
+            "clarify_objective",
+            "reformulation",
+            "evaluation",
+            "validation",
+            "execution_plan_decomposition",
         ]
         try:
             async with httpx.AsyncClient() as client:
@@ -588,139 +1018,251 @@ class ExecutionSupervisorLogic:
                         agent_skills = agent_info.get("skills", [])
                         if isinstance(agent_skills, list):
                             for skill in agent_skills:
-                                if isinstance(skill, str) and skill not in excluded_skills_for_decomposition_assignment:
-                                    if any(keyword in skill.lower() for keyword in execution_related_skills_keywords):
+                                if (
+                                    isinstance(skill, str)
+                                    and skill
+                                    not in excluded_skills_for_decomposition_assignment
+                                ):
+                                    if any(
+                                        keyword in skill.lower()
+                                        for keyword in execution_related_skills_keywords
+                                    ):
                                         all_skills.add(skill)
                         else:
-                            self.logger.warning(f"[{self.execution_plan_id}] Champ 'skills' mal formaté pour l'agent: {agent_info.get('name', 'Inconnu')}")
+                            self.logger.warning(
+                                f"[{self.execution_plan_id}] Champ 'skills' mal formaté pour l'agent: {agent_info.get('name', 'Inconnu')}"
+                            )
                 else:
-                    self.logger.error(f"[{self.execution_plan_id}] Réponse de /agents_status du GRA n'est pas une liste: {agents_list}")
+                    self.logger.error(
+                        f"[{self.execution_plan_id}] Réponse de /agents_status du GRA n'est pas une liste: {agents_list}"
+                    )
             if not all_skills:
-                 default_exec_skills = ["coding_python", "web_research", "software_testing", "document_synthesis", "general_analysis", "database_design"]
-                 self.logger.warning(f"[{self.execution_plan_id}] Aucune compétence d'exécution spécifique trouvée/filtrée via GRA, utilisation liste défaut: {default_exec_skills}")
-                 return default_exec_skills
-            self.logger.info(f"[{self.execution_plan_id}] Compétences d'exécution disponibles filtrées: {list(all_skills)}")
+                default_exec_skills = [
+                    "coding_python",
+                    "web_research",
+                    "software_testing",
+                    "document_synthesis",
+                    "general_analysis",
+                    "database_design",
+                ]
+                self.logger.warning(
+                    f"[{self.execution_plan_id}] Aucune compétence d'exécution spécifique trouvée/filtrée via GRA, utilisation liste défaut: {default_exec_skills}"
+                )
+                return default_exec_skills
+            self.logger.info(
+                f"[{self.execution_plan_id}] Compétences d'exécution disponibles filtrées: {list(all_skills)}"
+            )
             return list(all_skills)
         except Exception as e:
-            self.logger.error(f"[{self.execution_plan_id}] Erreur récupération compétences via GRA: {e}", exc_info=True)
-            default_exec_skills = ["coding_python", "web_research", "software_testing", "document_synthesis", "general_analysis", "database_design"]
-            self.logger.warning(f"[{self.execution_plan_id}] Utilisation liste compétences défaut due à erreur GRA: {default_exec_skills}")
+            self.logger.error(
+                f"[{self.execution_plan_id}] Erreur récupération compétences via GRA: {e}",
+                exc_info=True,
+            )
+            default_exec_skills = [
+                "coding_python",
+                "web_research",
+                "software_testing",
+                "document_synthesis",
+                "general_analysis",
+                "database_design",
+            ]
+            self.logger.warning(
+                f"[{self.execution_plan_id}] Utilisation liste compétences défaut due à erreur GRA: {default_exec_skills}"
+            )
             return default_exec_skills
 
-    async def _add_and_resolve_decomposed_tasks(self, tasks_json_list: List[Dict], initial_dependency_id: str, existing_local_id_map: Optional[Dict[str,str]] = None):
-        local_id_to_global_id_map = existing_local_id_map if existing_local_id_map is not None else {}
+    async def _add_and_resolve_decomposed_tasks(
+        self,
+        tasks_json_list: List[Dict],
+        initial_dependency_id: str,
+        existing_local_id_map: Optional[Dict[str, str]] = None,
+    ):
+        local_id_to_global_id_map = (
+            existing_local_id_map if existing_local_id_map is not None else {}
+        )
         if not existing_local_id_map:
             self._local_to_global_id_map_for_plan.clear()
             local_id_to_global_id_map = self._local_to_global_id_map_for_plan
 
+        nodes_to_add_to_graph = {}
 
-        nodes_to_add_to_graph = {} 
-        def first_pass_create_nodes_recursive(task_list_json: List[Dict], current_parent_global_id: Optional[str]):
+        def first_pass_create_nodes_recursive(
+            task_list_json: List[Dict], current_parent_global_id: Optional[str]
+        ):
             for task_json in task_list_json:
-                node_obj, _ = self._create_node_from_json_data(task_json, current_parent_global_id, local_id_to_global_id_map)
+                node_obj, _ = self._create_node_from_json_data(
+                    task_json, current_parent_global_id, local_id_to_global_id_map
+                )
                 nodes_to_add_to_graph[node_obj.id] = (node_obj, task_json)
                 json_sub_tasks = task_json.get("sous_taches", [])
                 if json_sub_tasks:
                     first_pass_create_nodes_recursive(json_sub_tasks, node_obj.id)
-        
+
         first_pass_create_nodes_recursive(tasks_json_list, None)
 
         for global_id, (node_obj, task_json_original) in nodes_to_add_to_graph.items():
             if node_obj.parent_id is None:
-                 node_obj.dependencies.append(initial_dependency_id)
+                node_obj.dependencies.append(initial_dependency_id)
 
             local_deps = task_json_original.get("dependances", [])
             for local_dep_id in local_deps:
-                if local_dep_id in local_id_to_global_id_map: 
+                if local_dep_id in local_id_to_global_id_map:
                     global_dep_id = local_id_to_global_id_map[local_dep_id]
                     if global_dep_id != node_obj.id:
                         node_obj.dependencies.append(global_dep_id)
                     else:
-                        self.logger.warning(f"[{self.execution_plan_id}] Tentative d'auto-dépendance (lot) pour {global_id}. Ignorée.")
+                        self.logger.warning(
+                            f"[{self.execution_plan_id}] Tentative d'auto-dépendance (lot) pour {global_id}. Ignorée."
+                        )
                 else:
-                    self.logger.warning(f"[{self.execution_plan_id}] Dépendance locale (lot) '{local_dep_id}' pour '{task_json_original.get('id')}' non trouvée dans la map actuelle. Si elle réfère à une tâche hors de ce lot, elle doit être déjà dans le graphe avec un ID global connu.")
-            
+                    self.logger.warning(
+                        f"[{self.execution_plan_id}] Dépendance locale (lot) '{local_dep_id}' pour '{task_json_original.get('id')}' non trouvée dans la map actuelle. Si elle réfère à une tâche hors de ce lot, elle doit être déjà dans le graphe avec un ID global connu."
+                    )
+
             node_obj.dependencies = list(set(node_obj.dependencies))
             self.task_graph.add_task(node_obj)
-            self.logger.info(f"[{self.execution_plan_id}] Tâche (lot) '{node_obj.objective}' (ID: {node_obj.id}) ajoutée/résolue avec parent '{node_obj.parent_id}' et dépendances: {node_obj.dependencies}.")
+            self.logger.info(
+                f"[{self.execution_plan_id}] Tâche (lot) '{node_obj.objective}' (ID: {node_obj.id}) ajoutée/résolue avec parent '{node_obj.parent_id}' et dépendances: {node_obj.dependencies}."
+            )
 
-    def _create_node_from_json_data(self, task_data_dict: Dict[str, Any], assigned_parent_id: Optional[str], local_id_map: Dict[str,str]) -> tuple[ExecutionTaskNode, Dict[str,Any]]:
+    def _create_node_from_json_data(
+        self,
+        task_data_dict: Dict[str, Any],
+        assigned_parent_id: Optional[str],
+        local_id_map: Dict[str, str],
+    ) -> tuple[ExecutionTaskNode, Dict[str, Any]]:
         local_id = task_data_dict.get("id")
         if not local_id:
             local_id = f"generated_local_id_{uuid.uuid4().hex[:6]}"
-            self.logger.warning(f"[{self.execution_plan_id}] Tâche JSON sans 'id' local, génération d'un ID local: {local_id}")
-        
-        clean_local_id = local_id.replace(' ', '_').replace('.', '_')
+            self.logger.warning(
+                f"[{self.execution_plan_id}] Tâche JSON sans 'id' local, génération d'un ID local: {local_id}"
+            )
+
+        clean_local_id = local_id.replace(" ", "_").replace(".", "_")
         global_task_id = f"exec_task_{clean_local_id}_{uuid.uuid4().hex[:6]}"
-        
+
         if local_id in local_id_map:
-            self.logger.warning(f"[{self.execution_plan_id}] L'ID local '{local_id}' a déjà été mappé à '{local_id_map[local_id]}'. Il est maintenant ré-mappé à '{global_task_id}'. Vérifiez l'unicité des ID locaux fournis par l'agent de décomposition.")
+            self.logger.warning(
+                f"[{self.execution_plan_id}] L'ID local '{local_id}' a déjà été mappé à '{local_id_map[local_id]}'. Il est maintenant ré-mappé à '{global_task_id}'. Vérifiez l'unicité des ID locaux fournis par l'agent de décomposition."
+            )
         local_id_map[local_id] = global_task_id
 
         node_meta = {
             "local_id_from_agent": local_id,
             "local_instructions": task_data_dict.get("instructions_locales", []),
-            "acceptance_criteria": task_data_dict.get("acceptance_criteria", [])
+            "acceptance_criteria": task_data_dict.get("acceptance_criteria", []),
         }
         if task_data_dict.get("nom"):
             node_meta["local_nom_from_agent"] = task_data_dict.get("nom")
-        
+
         task_type_str = task_data_dict.get("type", "exploratory").lower()
         try:
             task_type_enum = ExecutionTaskType(task_type_str)
         except ValueError:
-            self.logger.warning(f"[{self.execution_plan_id}] Type de tâche invalide '{task_type_str}' pour ID local '{local_id}'. Utilisation de 'exploratory' par défaut.")
+            self.logger.warning(
+                f"[{self.execution_plan_id}] Type de tâche invalide '{task_type_str}' pour ID local '{local_id}'. Utilisation de 'exploratory' par défaut."
+            )
             task_type_enum = ExecutionTaskType.EXPLORATORY
 
         new_node = ExecutionTaskNode(
             task_id=global_task_id,
-            objective=task_data_dict.get("description", task_data_dict.get("nom", "Objectif non défini par l'agent")),
+            objective=task_data_dict.get(
+                "description",
+                task_data_dict.get("nom", "Objectif non défini par l'agent"),
+            ),
             task_type=task_type_enum,
             assigned_agent_type=task_data_dict.get("assigned_agent_type"),
             dependencies=[],
-            parent_id=assigned_parent_id, 
+            parent_id=assigned_parent_id,
             meta=node_meta,
-            input_data_refs=task_data_dict.get("input_data_refs", {})
+            input_data_refs=task_data_dict.get("input_data_refs", {}),
         )
         return new_node, task_data_dict
 
-    async def _process_completed_exploratory_task(self, completed_task_node: ExecutionTaskNode, artifact_content_text: Optional[str]):
-        self.logger.info(f"[{self.execution_plan_id}] Traitement du résultat de la tâche exploratoire: {completed_task_node.id}")
+    async def _process_completed_exploratory_task(
+        self,
+        completed_task_node: ExecutionTaskNode,
+        artifact_content_text: Optional[str],
+    ):
+        self.logger.info(
+            f"[{self.execution_plan_id}] Traitement du résultat de la tâche exploratoire: {completed_task_node.id}"
+        )
         if not artifact_content_text:
-            self.logger.warning(f"[{self.execution_plan_id}] Tâche exploratoire {completed_task_node.id} complétée sans artefact textuel pour de nouvelles tâches.")
-            self.task_graph.update_task_state(completed_task_node.id, ExecutionTaskState.COMPLETED, "Exploration terminée, pas de nouvelles tâches spécifiées.")
+            self.logger.warning(
+                f"[{self.execution_plan_id}] Tâche exploratoire {completed_task_node.id} complétée sans artefact textuel pour de nouvelles tâches."
+            )
+            self.task_graph.update_task_state(
+                completed_task_node.id,
+                ExecutionTaskState.COMPLETED,
+                "Exploration terminée, pas de nouvelles tâches spécifiées.",
+            )
             return
 
         try:
             exploration_result = json.loads(artifact_content_text)
             new_sub_tasks_dicts = exploration_result.get("new_sub_tasks", [])
-            summary_from_artifact = exploration_result.get("summary", f"Exploration par {completed_task_node.id} terminée.")
+            summary_from_artifact = exploration_result.get(
+                "summary", f"Exploration par {completed_task_node.id} terminée."
+            )
 
-            self.task_graph.update_task_output(task_id=completed_task_node.id, summary=summary_from_artifact)
+            self.task_graph.update_task_output(
+                task_id=completed_task_node.id, summary=summary_from_artifact
+            )
 
             if not isinstance(new_sub_tasks_dicts, list):
-                self.logger.error(f"[{self.execution_plan_id}] La clé 'new_sub_tasks' de {completed_task_node.id} n'est pas une liste.")
-                self.task_graph.update_task_state(completed_task_node.id, ExecutionTaskState.FAILED, "Format incorrect de l'artefact (new_sub_tasks).")
+                self.logger.error(
+                    f"[{self.execution_plan_id}] La clé 'new_sub_tasks' de {completed_task_node.id} n'est pas une liste."
+                )
+                self.task_graph.update_task_state(
+                    completed_task_node.id,
+                    ExecutionTaskState.FAILED,
+                    "Format incorrect de l'artefact (new_sub_tasks).",
+                )
                 return
 
             if not new_sub_tasks_dicts:
-                self.logger.info(f"[{self.execution_plan_id}] Tâche exploratoire {completed_task_node.id} n'a pas défini de nouvelles sous-tâches.")
-                self.task_graph.update_task_state(completed_task_node.id, ExecutionTaskState.COMPLETED, summary_from_artifact)
+                self.logger.info(
+                    f"[{self.execution_plan_id}] Tâche exploratoire {completed_task_node.id} n'a pas défini de nouvelles sous-tâches."
+                )
+                self.task_graph.update_task_state(
+                    completed_task_node.id,
+                    ExecutionTaskState.COMPLETED,
+                    summary_from_artifact,
+                )
                 return
 
-            self.logger.info(f"[{self.execution_plan_id}] Tâche exploratoire {completed_task_node.id} a défini {len(new_sub_tasks_dicts)} nouvelle(s) sous-tâche(s).")
-            
-            await self._add_and_resolve_decomposed_tasks(
-                tasks_json_list=new_sub_tasks_dicts, 
-                initial_dependency_id=completed_task_node.id,
-                existing_local_id_map=self._local_to_global_id_map_for_plan
+            self.logger.info(
+                f"[{self.execution_plan_id}] Tâche exploratoire {completed_task_node.id} a défini {len(new_sub_tasks_dicts)} nouvelle(s) sous-tâche(s)."
             )
-            
-            self.task_graph.update_task_state(completed_task_node.id, ExecutionTaskState.COMPLETED, f"{summary_from_artifact} {len(new_sub_tasks_dicts)} nouvelles sous-tâches ajoutées.")
+
+            await self._add_and_resolve_decomposed_tasks(
+                tasks_json_list=new_sub_tasks_dicts,
+                initial_dependency_id=completed_task_node.id,
+                existing_local_id_map=self._local_to_global_id_map_for_plan,
+            )
+
+            self.task_graph.update_task_state(
+                completed_task_node.id,
+                ExecutionTaskState.COMPLETED,
+                f"{summary_from_artifact} {len(new_sub_tasks_dicts)} nouvelles sous-tâches ajoutées.",
+            )
 
         except json.JSONDecodeError:
-            self.logger.error(f"[{self.execution_plan_id}] Artefact de la tâche exploratoire {completed_task_node.id} JSON invalide: {artifact_content_text}")
-            self.task_graph.update_task_state(completed_task_node.id, ExecutionTaskState.FAILED, "Artefact d'exploration JSON invalide.")
+            self.logger.error(
+                f"[{self.execution_plan_id}] Artefact de la tâche exploratoire {completed_task_node.id} JSON invalide: {artifact_content_text}"
+            )
+            self.task_graph.update_task_state(
+                completed_task_node.id,
+                ExecutionTaskState.FAILED,
+                "Artefact d'exploration JSON invalide.",
+            )
         except Exception as e:
-            self.logger.error(f"[{self.execution_plan_id}] Erreur traitement résultat tâche exploratoire {completed_task_node.id}: {e}", exc_info=True)
-            self.task_graph.update_task_state(completed_task_node.id, ExecutionTaskState.FAILED, f"Erreur traitement résultat exploration: {str(e)}")
+            self.logger.error(
+                f"[{self.execution_plan_id}] Erreur traitement résultat tâche exploratoire {completed_task_node.id}: {e}",
+                exc_info=True,
+            )
+            self.task_graph.update_task_state(
+                completed_task_node.id,
+                ExecutionTaskState.FAILED,
+                f"Erreur traitement résultat exploration: {str(e)}",
+            )

--- a/src/orchestrators/global_supervisor_logic.py
+++ b/src/orchestrators/global_supervisor_logic.py
@@ -5,6 +5,8 @@ import json
 import httpx
 from typing import Optional, Dict, Any, List
 from datetime import datetime, timezone
+import os
+import time
 
 import firebase_admin
 from firebase_admin import credentials, firestore
@@ -20,14 +22,19 @@ from src.shared.execution_task_graph_management import ExecutionTaskGraph
 from a2a.types import Task, TaskState, TextPart
 
 from src.services.environment_manager.environment_manager import EnvironmentManager
+from src.shared.agent_state import AgentOperationalState
 
 
 logger = logging.getLogger(__name__)
 if not logger.hasHandlers():
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
 GLOBAL_PLANS_FIRESTORE_COLLECTION = "global_plans"
 MAX_CLARIFICATION_ATTEMPTS = 3
+
 
 class GlobalPlanState:
     INITIAL_OBJECTIVE_RECEIVED = "INITIAL_OBJECTIVE_RECEIVED"
@@ -46,14 +53,14 @@ class GlobalPlanState:
     FAILED_MAX_CLARIFICATION_ATTEMPTS = "FAILED_MAX_CLARIFICATION_ATTEMPTS"
     FAILED_AGENT_ERROR = "FAILED_AGENT_ERROR"
 
+
 class GlobalSupervisorLogic:
     def __init__(self):
         self._gra_base_url: Optional[str] = None
         self.db = None
         logger.info("GlobalSupervisorLogic initialisé.")
         self.plan_environment_id = None
-    
-        
+
         try:
             if not firebase_admin._apps:
                 cred = credentials.ApplicationDefault()
@@ -62,16 +69,58 @@ class GlobalSupervisorLogic:
             self.db = firestore.client()
             logger.info("[GlobalSupervisor] Client Firestore obtenu.")
         except Exception as e:
-            logger.critical(f"[GlobalSupervisor] Échec de l'initialisation de Firestore: {e}.", exc_info=True)
+            logger.critical(
+                f"[GlobalSupervisor] Échec de l'initialisation de Firestore: {e}.",
+                exc_info=True,
+            )
         # Instancier le manager d'environnement
         try:
             self.environment_manager = EnvironmentManager()
             logging.info("GlobalSupervisorLogic: EnvironmentManager initialized.")
         except Exception as e:
             self.environment_manager = None
-            logging.error(f"GlobalSupervisorLogic: Failed to initialize EnvironmentManager: {e}", exc_info=True)
+            logging.error(
+                f"GlobalSupervisorLogic: Failed to initialize EnvironmentManager: {e}",
+                exc_info=True,
+            )
 
+        # Operational status tracking
+        self.operational_state: AgentOperationalState = AgentOperationalState.IDLE
+        self.status_detail: str | None = None
+        self.last_activity_time: float = time.time()
+        self.gra_url: Optional[str] = None
 
+    def get_status(self) -> Dict[str, Any]:
+        return {
+            "state": self.operational_state.value,
+            "detail": self.status_detail,
+            "last_activity_time": self.last_activity_time,
+        }
+
+    async def _notify_gra_of_status_change(self):
+        if not self.gra_url:
+            self.gra_url = os.environ.get("GRA_PUBLIC_URL") or await get_gra_base_url()
+        if not self.gra_url:
+            logger.warning(
+                "[GlobalSupervisor] GRA_PUBLIC_URL non configuré et découverte impossible."
+            )
+            return
+        payload = self.get_status()
+        payload["name"] = os.environ.get("AGENT_NAME", self.__class__.__name__)
+        try:
+            async with httpx.AsyncClient() as client:
+                await client.post(
+                    f"{self.gra_url}/agent_status_update", json=payload, timeout=5.0
+                )
+            logger.debug(f"[GlobalSupervisor] Statut notifié au GRA: {payload}")
+        except Exception as e:
+            logger.error(f"[GlobalSupervisor] Échec notification statut GRA: {e}")
+
+    async def _update_status(self, state: AgentOperationalState, detail: str):
+        self.operational_state = state
+        self.status_detail = detail
+        self.last_activity_time = time.time()
+        await self._notify_gra_of_status_change()
 
     async def _ensure_gra_url(self):
         if not self._gra_base_url:
@@ -86,128 +135,256 @@ class GlobalSupervisorLogic:
         if not gra_url:
             return None
 
-        logger.info(f"[GlobalSupervisor] Demande au GRA ({gra_url}) un agent avec la compétence: '{skill}'")
-        
+        logger.info(
+            f"[GlobalSupervisor] Demande au GRA ({gra_url}) un agent avec la compétence: '{skill}'"
+        )
+
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.get(f"{gra_url}/agents", params={"skill": skill}, timeout=30.0)
+                response = await client.get(
+                    f"{gra_url}/agents", params={"skill": skill}, timeout=30.0
+                )
                 response.raise_for_status()
                 data = response.json()
 
                 if data and isinstance(data, list) and len(data) > 0:
                     agent = data[0]
-                    
-                    agent_target_url = agent.get('internal_url')
-                    
-                    logger.info(f"[GlobalSupervisor] Agent trouvé pour '{skill}': {agent.get('name')} à l'URL {agent_target_url}")
+
+                    agent_target_url = agent.get("internal_url")
+
+                    logger.info(
+                        f"[GlobalSupervisor] Agent trouvé pour '{skill}': {agent.get('name')} à l'URL {agent_target_url}"
+                    )
                     return agent_target_url
                 else:
-                    logger.error(f"[GlobalSupervisor] Aucun agent trouvé pour la compétence '{skill}'. Réponse du GRA: {data}")
+                    logger.error(
+                        f"[GlobalSupervisor] Aucun agent trouvé pour la compétence '{skill}'. Réponse du GRA: {data}"
+                    )
                     return None
 
         except httpx.HTTPStatusError as e:
-            logger.error(f"[GlobalSupervisor] Erreur HTTP en contactant le GRA : {e.response.text}")
+            logger.error(
+                f"[GlobalSupervisor] Erreur HTTP en contactant le GRA : {e.response.text}"
+            )
         except httpx.RequestError as e:
-            logger.error(f"[GlobalSupervisor] Erreur de requête en contactant le GRA : {e}")
+            logger.error(
+                f"[GlobalSupervisor] Erreur de requête en contactant le GRA : {e}"
+            )
         except Exception as e:
-            logger.error(f"[GlobalSupervisor] Erreur inattendue en contactant le GRA : {e}", exc_info=True)
-        
-        return None
-    
+            logger.error(
+                f"[GlobalSupervisor] Erreur inattendue en contactant le GRA : {e}",
+                exc_info=True,
+            )
 
-    async def _save_global_plan_state(self, global_plan_id: str, plan_data_to_update: Dict[str, Any]):
+        return None
+
+    async def _save_global_plan_state(
+        self, global_plan_id: str, plan_data_to_update: Dict[str, Any]
+    ):
         if not self.db:
-            logger.error(f"[GlobalSupervisor] Client Firestore non disponible. Impossible de sauvegarder plan '{global_plan_id}'.")
+            logger.error(
+                f"[GlobalSupervisor] Client Firestore non disponible. Impossible de sauvegarder plan '{global_plan_id}'."
+            )
             return
 
-        doc_ref = self.db.collection(GLOBAL_PLANS_FIRESTORE_COLLECTION).document(global_plan_id)
-        plan_data_to_update['updated_at'] = datetime.now(timezone.utc).isoformat()
-        
+        doc_ref = self.db.collection(GLOBAL_PLANS_FIRESTORE_COLLECTION).document(
+            global_plan_id
+        )
+        plan_data_to_update["updated_at"] = datetime.now(timezone.utc).isoformat()
+
         try:
             await asyncio.to_thread(doc_ref.set, plan_data_to_update, merge=True)
-            logger.info(f"[GlobalSupervisor] État plan global '{global_plan_id}' sauvegardé/mis à jour sur Firestore. Données: {plan_data_to_update}")
+            logger.info(
+                f"[GlobalSupervisor] État plan global '{global_plan_id}' sauvegardé/mis à jour sur Firestore. Données: {plan_data_to_update}"
+            )
         except Exception as e:
-            logger.error(f"[GlobalSupervisor] Erreur sauvegarde plan '{global_plan_id}' sur Firestore: {e}", exc_info=True)
+            logger.error(
+                f"[GlobalSupervisor] Erreur sauvegarde plan '{global_plan_id}' sur Firestore: {e}",
+                exc_info=True,
+            )
 
-    async def _load_global_plan_state(self, global_plan_id: str) -> Optional[Dict[str, Any]]:
+    async def _load_global_plan_state(
+        self, global_plan_id: str
+    ) -> Optional[Dict[str, Any]]:
         if not self.db:
-            logger.error(f"[GlobalSupervisor] Client Firestore non disponible. Impossible de charger plan '{global_plan_id}'.")
+            logger.error(
+                f"[GlobalSupervisor] Client Firestore non disponible. Impossible de charger plan '{global_plan_id}'."
+            )
             return None
-            
-        doc_ref = self.db.collection(GLOBAL_PLANS_FIRESTORE_COLLECTION).document(global_plan_id)
+
+        doc_ref = self.db.collection(GLOBAL_PLANS_FIRESTORE_COLLECTION).document(
+            global_plan_id
+        )
         try:
             doc = await asyncio.to_thread(doc_ref.get)
             if doc.exists:
-                logger.info(f"[GlobalSupervisor] État plan global '{global_plan_id}' chargé depuis Firestore.")
+                logger.info(
+                    f"[GlobalSupervisor] État plan global '{global_plan_id}' chargé depuis Firestore."
+                )
                 return doc.to_dict()
             else:
-                logger.warning(f"[GlobalSupervisor] Plan global '{global_plan_id}' non trouvé sur Firestore.")
+                logger.warning(
+                    f"[GlobalSupervisor] Plan global '{global_plan_id}' non trouvé sur Firestore."
+                )
                 return None
         except Exception as e:
-            logger.error(f"[GlobalSupervisor] Erreur chargement plan '{global_plan_id}' depuis Firestore: {e}", exc_info=True)
+            logger.error(
+                f"[GlobalSupervisor] Erreur chargement plan '{global_plan_id}' depuis Firestore: {e}",
+                exc_info=True,
+            )
             return None
-    async def start_new_global_plan(self, raw_objective: str, user_id: Optional[str] = "default_user") -> Dict[str, Any]:
+
+    async def start_new_global_plan(
+        self, raw_objective: str, user_id: Optional[str] = "default_user"
+    ) -> Dict[str, Any]:
 
         global_plan_id = f"gplan_{uuid.uuid4().hex[:12]}"
-        logger.info(f"[GlobalSupervisor] Démarrage nouveau plan global '{global_plan_id}' pour objectif: '{raw_objective}'")
+        logger.info(
+            f"[GlobalSupervisor] Démarrage nouveau plan global '{global_plan_id}' pour objectif: '{raw_objective}'"
+        )
+        await self._update_status(
+            AgentOperationalState.WORKING, f"Création plan {global_plan_id}"
+        )
         plan_data = {
-            "user_id": user_id, "raw_objective": raw_objective, "clarified_objective": None,
+            "user_id": user_id,
+            "raw_objective": raw_objective,
+            "clarified_objective": None,
             "current_supervisor_state": GlobalPlanState.INITIAL_OBJECTIVE_RECEIVED,
-            "task_type_estimation": None, "last_question_to_user": None,
-            "conversation_history": [], "clarification_attempts": 0,
-            "team1_plan_id": None, "created_at": datetime.now(timezone.utc).isoformat()
+            "task_type_estimation": None,
+            "last_question_to_user": None,
+            "conversation_history": [],
+            "clarification_attempts": 0,
+            "team1_plan_id": None,
+            "created_at": datetime.now(timezone.utc).isoformat(),
         }
-        
+
         await self._save_global_plan_state(global_plan_id, plan_data)
-        logger.info(f"[GlobalSupervisor] Plan global '{global_plan_id}' créé ,création de l'environnement isolé pour l'exécution.") 
+        logger.info(
+            f"[GlobalSupervisor] Plan global '{global_plan_id}' créé ,création de l'environnement isolé pour l'exécution."
+        )
         if not self.environment_manager:
             # créer un environnement isolé par défaut si le manager n'est pas initialisé
-            logger.warning("[GlobalSupervisor] EnvironmentManager non initialisé, création d'un environnement isolé par défaut.")
+            logger.warning(
+                "[GlobalSupervisor] EnvironmentManager non initialisé, création d'un environnement isolé par défaut."
+            )
             self.environment_manager = EnvironmentManager()
         if not self.environment_manager:
-            logger.error("[GlobalSupervisor] Impossible de créer un environnement isolé, EnvironmentManager non disponible.")
-            await self._save_global_plan_state(global_plan_id, {"current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR, "error_message": "EnvironmentManager not available"})
-            return {"status": "error", "message": "EnvironmentManager not available", "global_plan_id": global_plan_id}
-        self.plan_environment_id = await self.environment_manager.get_environment_or_fallback(global_plan_id)
+            logger.error(
+                "[GlobalSupervisor] Impossible de créer un environnement isolé, EnvironmentManager non disponible."
+            )
+            await self._save_global_plan_state(
+                global_plan_id,
+                {
+                    "current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR,
+                    "error_message": "EnvironmentManager not available",
+                },
+            )
+            return {
+                "status": "error",
+                "message": "EnvironmentManager not available",
+                "global_plan_id": global_plan_id,
+            }
+        self.plan_environment_id = (
+            await self.environment_manager.get_environment_or_fallback(global_plan_id)
+        )
         plan_data["environment_id"] = self.plan_environment_id
         if self.plan_environment_id:
-            await self._save_global_plan_state(global_plan_id, {"environment_id": self.plan_environment_id})
+            await self._save_global_plan_state(
+                global_plan_id, {"environment_id": self.plan_environment_id}
+            )
         if not self.plan_environment_id:
-            logger.error(f"[GlobalSupervisor] Échec de la création de l'environnement pour plan '{global_plan_id}'.")
-            await self._save_global_plan_state(global_plan_id, {
-                "current_supervisor_state": GlobalPlanState.FAILED_ENVIRONMENT_CREATION,
-                "error_message": "Environment creation failed"
-            })
-            return {"status": "error", "message": "Environment creation failed", "global_plan_id": global_plan_id}
-        logger.info(f"[GlobalSupervisor] Environnement isolé '{self.plan_environment_id}' créé et prêt pour plan global '{global_plan_id}'.")
+            logger.error(
+                f"[GlobalSupervisor] Échec de la création de l'environnement pour plan '{global_plan_id}'."
+            )
+            await self._save_global_plan_state(
+                global_plan_id,
+                {
+                    "current_supervisor_state": GlobalPlanState.FAILED_ENVIRONMENT_CREATION,
+                    "error_message": "Environment creation failed",
+                },
+            )
+            return {
+                "status": "error",
+                "message": "Environment creation failed",
+                "global_plan_id": global_plan_id,
+            }
+        logger.info(
+            f"[GlobalSupervisor] Environnement isolé '{self.plan_environment_id}' créé et prêt pour plan global '{global_plan_id}'."
+        )
+        await self._update_status(
+            AgentOperationalState.IDLE, f"Plan {global_plan_id} créé"
+        )
         return await self._trigger_clarification_step(global_plan_id, raw_objective, [])
 
-    async def _trigger_clarification_step(self, global_plan_id: str, text_for_clarification: str, conversation_history: List[Dict[str,str]]) -> Dict[str, Any]:
-        await self._save_global_plan_state(global_plan_id, {"current_supervisor_state": GlobalPlanState.OBJECTIVE_BEING_CLARIFIED_BY_AGENT})
+    async def _trigger_clarification_step(
+        self,
+        global_plan_id: str,
+        text_for_clarification: str,
+        conversation_history: List[Dict[str, str]],
+    ) -> Dict[str, Any]:
+        await self._save_global_plan_state(
+            global_plan_id,
+            {
+                "current_supervisor_state": GlobalPlanState.OBJECTIVE_BEING_CLARIFIED_BY_AGENT
+            },
+        )
+        await self._update_status(
+            AgentOperationalState.WORKING, f"Clarification {global_plan_id}"
+        )
         ui_agent_skill = ACTION_CLARIFY_OBJECTIVE
-        
+
         ui_agent_url = await self._get_agent_url_from_gra(ui_agent_skill)
-        logger.info(f"[GlobalSupervisor] Plan '{global_plan_id}': Appel à l'agent de clarification d'objectif ({ui_agent_skill}) à l'URL {ui_agent_url}")
+        logger.info(
+            f"[GlobalSupervisor] Plan '{global_plan_id}': Appel à l'agent de clarification d'objectif ({ui_agent_skill}) à l'URL {ui_agent_url}"
+        )
         if not ui_agent_url:
-            logger.error(f"[GlobalSupervisor] UserInteractionAgent introuvable pour '{ui_agent_skill}'. Plan '{global_plan_id}'.")
-            await self._save_global_plan_state(global_plan_id, {"current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR, "error_message": "UserInteractionAgent not found"})
-            return {"status": "error", "message": "UserInteractionAgent not found", "global_plan_id": global_plan_id}
+            logger.error(
+                f"[GlobalSupervisor] UserInteractionAgent introuvable pour '{ui_agent_skill}'. Plan '{global_plan_id}'."
+            )
+            await self._save_global_plan_state(
+                global_plan_id,
+                {
+                    "current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR,
+                    "error_message": "UserInteractionAgent not found",
+                },
+            )
+            return {
+                "status": "error",
+                "message": "UserInteractionAgent not found",
+                "global_plan_id": global_plan_id,
+            }
 
         agent_input_payload = {
             "action": ACTION_CLARIFY_OBJECTIVE,
             "current_objective_or_response": text_for_clarification,
-            "conversation_history": conversation_history
+            "conversation_history": conversation_history,
         }
         agent_input_json_str = json.dumps(agent_input_payload)
-        logger.info(f"[GlobalSupervisor] Appel UI Agent ({ui_agent_url}) pour plan '{global_plan_id}'. Payload: {agent_input_payload}")
+        logger.info(
+            f"[GlobalSupervisor] Appel UI Agent ({ui_agent_url}) pour plan '{global_plan_id}'. Payload: {agent_input_payload}"
+        )
         a2a_task_result: Optional[Task] = await call_a2a_agent(
-            agent_url=ui_agent_url, input_text=agent_input_json_str, initial_context_id=global_plan_id
+            agent_url=ui_agent_url,
+            input_text=agent_input_json_str,
+            initial_context_id=global_plan_id,
         )
 
         if not a2a_task_result or not a2a_task_result.status:
-            logger.error(f"[GlobalSupervisor] Échec appel/réponse invalide de UserInteractionAgent pour plan '{global_plan_id}'.")
-            await self._save_global_plan_state(global_plan_id, {"current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR, "error_message": "UserInteractionAgent call failed or invalid response"})
-            return {"status": "error", "message": "Failed call or invalid response from UserInteractionAgent", "global_plan_id": global_plan_id}
+            logger.error(
+                f"[GlobalSupervisor] Échec appel/réponse invalide de UserInteractionAgent pour plan '{global_plan_id}'."
+            )
+            await self._save_global_plan_state(
+                global_plan_id,
+                {
+                    "current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR,
+                    "error_message": "UserInteractionAgent call failed or invalid response",
+                },
+            )
+            return {
+                "status": "error",
+                "message": "Failed call or invalid response from UserInteractionAgent",
+                "global_plan_id": global_plan_id,
+            }
 
         raw_artifact_text = None
 
@@ -215,176 +392,344 @@ class GlobalSupervisorLogic:
             first_artifact = a2a_task_result.artifacts[0]
             if first_artifact.parts and len(first_artifact.parts) > 0:
                 part_content = first_artifact.parts[0]
-                if hasattr(part_content, 'root') and isinstance(part_content.root, TextPart) and part_content.root.text:
+                if (
+                    hasattr(part_content, "root")
+                    and isinstance(part_content.root, TextPart)
+                    and part_content.root.text
+                ):
                     raw_artifact_text = part_content.root.text
                 elif isinstance(part_content, TextPart) and part_content.text:
-                     raw_artifact_text = part_content.text
-                
+                    raw_artifact_text = part_content.text
+
                 if raw_artifact_text:
                     try:
                         clarification_artifact_content = json.loads(raw_artifact_text)
                     except json.JSONDecodeError as e:
-                        logger.error(f"[GlobalSupervisor] Impossible de parser l'artefact JSON de UI Agent: {e} - Data: {raw_artifact_text}")
-        
-        if clarification_artifact_content is None: 
-            logger.warning(f"[GlobalSupervisor] Aucun artefact JSON valide reçu de UserInteractionAgent. État A2A: {a2a_task_result.status.state.value}")
-            await self._save_global_plan_state(global_plan_id, {"current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR, "error_message": "UserInteractionAgent missing valid artifact"})
-            return {"status": "error", "message": "UserInteractionAgent did not return a valid artifact", "global_plan_id": global_plan_id}
+                        logger.error(
+                            f"[GlobalSupervisor] Impossible de parser l'artefact JSON de UI Agent: {e} - Data: {raw_artifact_text}"
+                        )
 
+        if clarification_artifact_content is None:
+            logger.warning(
+                f"[GlobalSupervisor] Aucun artefact JSON valide reçu de UserInteractionAgent. État A2A: {a2a_task_result.status.state.value}"
+            )
+            await self._save_global_plan_state(
+                global_plan_id,
+                {
+                    "current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR,
+                    "error_message": "UserInteractionAgent missing valid artifact",
+                },
+            )
+            return {
+                "status": "error",
+                "message": "UserInteractionAgent did not return a valid artifact",
+                "global_plan_id": global_plan_id,
+            }
 
         agent_payload_status = clarification_artifact_content.get("status")
-        task_type_estimation = clarification_artifact_content.get("task_type_estimation")
+        task_type_estimation = clarification_artifact_content.get(
+            "task_type_estimation"
+        )
         missing_summary = clarification_artifact_content.get("missing_elements_summary")
-        tentative_objective = clarification_artifact_content.get("tentatively_enriched_objective")
+        tentative_objective = clarification_artifact_content.get(
+            "tentatively_enriched_objective"
+        )
         proposed_elements = clarification_artifact_content.get("proposed_elements")
-        
-        logger.info(f"[GS] Plan '{global_plan_id}' - UI Agent payload: status='{agent_payload_status}', type='{task_type_estimation}'")
 
-        current_plan_data_for_attempts = await self._load_global_plan_state(global_plan_id) or {}
-        current_attempts = current_plan_data_for_attempts.get("clarification_attempts", 0)
+        logger.info(
+            f"[GS] Plan '{global_plan_id}' - UI Agent payload: status='{agent_payload_status}', type='{task_type_estimation}'"
+        )
+
+        current_plan_data_for_attempts = (
+            await self._load_global_plan_state(global_plan_id) or {}
+        )
+        current_attempts = current_plan_data_for_attempts.get(
+            "clarification_attempts", 0
+        )
 
         updated_plan_fields = {
             "task_type_estimation": task_type_estimation,
             "missing_elements_summary": missing_summary,
             "last_agent_response_artifact": clarification_artifact_content,
             "tentatively_enriched_objective_from_agent": tentative_objective,
-            "proposed_elements_from_agent": proposed_elements
+            "proposed_elements_from_agent": proposed_elements,
         }
 
-        if a2a_task_result.status.state.value == TaskState.completed.value and agent_payload_status == "clarified":
-            final_clarified_objective = clarification_artifact_content.get("clarified_objective", tentative_objective)
-            if not final_clarified_objective: final_clarified_objective = text_for_clarification
-            
-            logger.info(f"[GS] Plan '{global_plan_id}': Objectif clarifié par LLM: '{final_clarified_objective}'")
+        if (
+            a2a_task_result.status.state.value == TaskState.completed.value
+            and agent_payload_status == "clarified"
+        ):
+            final_clarified_objective = clarification_artifact_content.get(
+                "clarified_objective", tentative_objective
+            )
+            if not final_clarified_objective:
+                final_clarified_objective = text_for_clarification
+
+            logger.info(
+                f"[GS] Plan '{global_plan_id}': Objectif clarifié par LLM: '{final_clarified_objective}'"
+            )
             updated_plan_fields["clarified_objective"] = final_clarified_objective
-            updated_plan_fields["current_supervisor_state"] = GlobalPlanState.OBJECTIVE_CLARIFIED
+            updated_plan_fields["current_supervisor_state"] = (
+                GlobalPlanState.OBJECTIVE_CLARIFIED
+            )
             updated_plan_fields["last_question_to_user"] = None
             await self._save_global_plan_state(global_plan_id, updated_plan_fields)
-            
-            await self._initiate_team1_planning(global_plan_id, final_clarified_objective)
-            return {"status": GlobalPlanState.OBJECTIVE_CLARIFIED, "clarified_objective": final_clarified_objective, "task_type_estimation": task_type_estimation, "global_plan_id": global_plan_id}
+            await self._update_status(
+                AgentOperationalState.WORKING, f"TEAM1 planning for {global_plan_id}"
+            )
+            await self._initiate_team1_planning(
+                global_plan_id, final_clarified_objective
+            )
+            await self._update_status(
+                AgentOperationalState.IDLE, f"Objectif clarifié pour {global_plan_id}"
+            )
+            return {
+                "status": GlobalPlanState.OBJECTIVE_CLARIFIED,
+                "clarified_objective": final_clarified_objective,
+                "task_type_estimation": task_type_estimation,
+                "global_plan_id": global_plan_id,
+            }
 
-        elif a2a_task_result.status.state.value == TaskState.input_required.value and agent_payload_status == "needs_confirmation_or_clarification":
+        elif (
+            a2a_task_result.status.state.value == TaskState.input_required.value
+            and agent_payload_status == "needs_confirmation_or_clarification"
+        ):
             question_for_user = clarification_artifact_content.get("question_for_user")
-            logger.info(f"[GS] Plan '{global_plan_id}': UI Agent requiert entrée. Question: '{question_for_user}'")
-            
+            logger.info(
+                f"[GS] Plan '{global_plan_id}': UI Agent requiert entrée. Question: '{question_for_user}'"
+            )
+
             updated_plan_fields["last_question_to_user"] = question_for_user
-            updated_plan_fields["current_supervisor_state"] = GlobalPlanState.CLARIFICATION_PENDING_USER_INPUT
+            updated_plan_fields["current_supervisor_state"] = (
+                GlobalPlanState.CLARIFICATION_PENDING_USER_INPUT
+            )
             updated_plan_fields["clarification_attempts"] = current_attempts + 1
             await self._save_global_plan_state(global_plan_id, updated_plan_fields)
+            await self._update_status(
+                AgentOperationalState.IDLE,
+                f"Clarification en attente pour {global_plan_id}",
+            )
             return {
                 "status": "clarification_pending",
-                "question": question_for_user, 
-                "task_type_estimation": task_type_estimation, 
+                "question": question_for_user,
+                "task_type_estimation": task_type_estimation,
                 "global_plan_id": global_plan_id,
                 "tentatively_enriched_objective": tentative_objective,
-                "proposed_elements": proposed_elements
+                "proposed_elements": proposed_elements,
             }
         else:
             error_msg = f"État A2A ({a2a_task_result.status.state.value}) et/ou statut payload agent ('{agent_payload_status}') incohérents ou échec."
-            logger.error(f"[GS] Plan '{global_plan_id}': {error_msg} Artefact: {clarification_artifact_content}")
-            updated_plan_fields["current_supervisor_state"] = GlobalPlanState.FAILED_AGENT_ERROR
+            logger.error(
+                f"[GS] Plan '{global_plan_id}': {error_msg} Artefact: {clarification_artifact_content}"
+            )
+            updated_plan_fields["current_supervisor_state"] = (
+                GlobalPlanState.FAILED_AGENT_ERROR
+            )
             updated_plan_fields["error_message"] = error_msg
             await self._save_global_plan_state(global_plan_id, updated_plan_fields)
-            return {"status": "error", "message": error_msg, "global_plan_id": global_plan_id, "artifact": clarification_artifact_content}
+            await self._update_status(
+                AgentOperationalState.ERROR, f"Erreur clarification {global_plan_id}"
+            )
+            return {
+                "status": "error",
+                "message": error_msg,
+                "global_plan_id": global_plan_id,
+                "artifact": clarification_artifact_content,
+            }
 
-
-    async def process_user_clarification_response(self, global_plan_id: str, user_response: str) -> Dict[str, Any]:
-        logger.info(f"[GS] Plan '{global_plan_id}': Réponse utilisateur: '{user_response}'")
+    async def process_user_clarification_response(
+        self, global_plan_id: str, user_response: str
+    ) -> Dict[str, Any]:
+        logger.info(
+            f"[GS] Plan '{global_plan_id}': Réponse utilisateur: '{user_response}'"
+        )
         current_plan_data = await self._load_global_plan_state(global_plan_id)
         if not current_plan_data:
-            return {"status": "error", "message": f"Plan global '{global_plan_id}' non trouvé.", "global_plan_id": global_plan_id}
+            return {
+                "status": "error",
+                "message": f"Plan global '{global_plan_id}' non trouvé.",
+                "global_plan_id": global_plan_id,
+            }
 
         current_attempts = current_plan_data.get("clarification_attempts", 0)
         if current_attempts >= MAX_CLARIFICATION_ATTEMPTS:
-            logger.warning(f"[GS] Plan '{global_plan_id}': Max tentatives ({MAX_CLARIFICATION_ATTEMPTS}) atteint. Échec.")
-            await self._save_global_plan_state(global_plan_id, {"current_supervisor_state": GlobalPlanState.FAILED_MAX_CLARIFICATION_ATTEMPTS})
-            return {"status": "max_clarification_attempts_reached", "message": f"Max {MAX_CLARIFICATION_ATTEMPTS} tentatives atteintes.", "global_plan_id": global_plan_id}
-        
-        last_question = current_plan_data.get("last_question_to_user")
-        updated_conversation_history: List[Dict[str,str]] = current_plan_data.get("conversation_history", [])
-        if last_question: 
-            updated_conversation_history.append({"agent_question": last_question, "user_answer": user_response})
-        else:
-            updated_conversation_history.append({"agent_question": "N/A (User provided additional info)", "user_answer": user_response})
-        
-        await self._save_global_plan_state(global_plan_id, {
-            "conversation_history": updated_conversation_history,
-            "last_question_to_user": None 
-        })
-        return await self._trigger_clarification_step(global_plan_id, user_response, updated_conversation_history)
+            logger.warning(
+                f"[GS] Plan '{global_plan_id}': Max tentatives ({MAX_CLARIFICATION_ATTEMPTS}) atteint. Échec."
+            )
+            await self._save_global_plan_state(
+                global_plan_id,
+                {
+                    "current_supervisor_state": GlobalPlanState.FAILED_MAX_CLARIFICATION_ATTEMPTS
+                },
+            )
+            return {
+                "status": "max_clarification_attempts_reached",
+                "message": f"Max {MAX_CLARIFICATION_ATTEMPTS} tentatives atteintes.",
+                "global_plan_id": global_plan_id,
+            }
 
-    async def accept_objective_and_initiate_team1(self, global_plan_id: str, user_provided_objective: Optional[str] = None) -> Dict[str, Any]:
+        last_question = current_plan_data.get("last_question_to_user")
+        updated_conversation_history: List[Dict[str, str]] = current_plan_data.get(
+            "conversation_history", []
+        )
+        if last_question:
+            updated_conversation_history.append(
+                {"agent_question": last_question, "user_answer": user_response}
+            )
+        else:
+            updated_conversation_history.append(
+                {
+                    "agent_question": "N/A (User provided additional info)",
+                    "user_answer": user_response,
+                }
+            )
+
+        await self._save_global_plan_state(
+            global_plan_id,
+            {
+                "conversation_history": updated_conversation_history,
+                "last_question_to_user": None,
+            },
+        )
+        return await self._trigger_clarification_step(
+            global_plan_id, user_response, updated_conversation_history
+        )
+
+    async def accept_objective_and_initiate_team1(
+        self, global_plan_id: str, user_provided_objective: Optional[str] = None
+    ) -> Dict[str, Any]:
         """
         L'utilisateur force l'acceptation de l'objectif actuel (ou d'une version fournie)
         et lance la planification TEAM 1.
         """
-        logger.info(f"[GS] Plan '{global_plan_id}': Acceptation forcée de l'objectif par l'utilisateur.")
+        logger.info(
+            f"[GS] Plan '{global_plan_id}': Acceptation forcée de l'objectif par l'utilisateur."
+        )
         current_plan_data = await self._load_global_plan_state(global_plan_id)
         if not current_plan_data:
-            return {"status": "error", "message": f"Plan global '{global_plan_id}' non trouvé.", "global_plan_id": global_plan_id}
+            return {
+                "status": "error",
+                "message": f"Plan global '{global_plan_id}' non trouvé.",
+                "global_plan_id": global_plan_id,
+            }
 
         objective_to_use = user_provided_objective
         if not objective_to_use:
-            objective_to_use = current_plan_data.get("last_agent_response_artifact", {}).get("tentatively_enriched_objective")
+            objective_to_use = current_plan_data.get(
+                "last_agent_response_artifact", {}
+            ).get("tentatively_enriched_objective")
             if not objective_to_use:
-                 objective_to_use = current_plan_data.get("clarified_objective")
+                objective_to_use = current_plan_data.get("clarified_objective")
             if not objective_to_use:
                 objective_to_use = current_plan_data.get("raw_objective")
 
         if not objective_to_use:
-             logger.error(f"[GS] Plan '{global_plan_id}': Aucun objectif (brut, enrichi, ou clarifié) à utiliser pour TEAM 1.")
-             await self._save_global_plan_state(global_plan_id, {"current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR, "error_message": "No objective found to start TEAM1 planning."})
-             return {"status": "error", "message": "No objective available to start planning.", "global_plan_id": global_plan_id}
+            logger.error(
+                f"[GS] Plan '{global_plan_id}': Aucun objectif (brut, enrichi, ou clarifié) à utiliser pour TEAM 1."
+            )
+            await self._save_global_plan_state(
+                global_plan_id,
+                {
+                    "current_supervisor_state": GlobalPlanState.FAILED_AGENT_ERROR,
+                    "error_message": "No objective found to start TEAM1 planning.",
+                },
+            )
+            return {
+                "status": "error",
+                "message": "No objective available to start planning.",
+                "global_plan_id": global_plan_id,
+            }
 
-        logger.info(f"[GS] Plan '{global_plan_id}': Utilisation de l'objectif suivant pour TEAM 1: '{objective_to_use}'")
-        
-        await self._save_global_plan_state(global_plan_id, {
-            "clarified_objective": objective_to_use,
-            "current_supervisor_state": GlobalPlanState.OBJECTIVE_CLARIFIED,
-            "last_question_to_user": None,
-            "user_forced_clarification": True
-        })
+        logger.info(
+            f"[GS] Plan '{global_plan_id}': Utilisation de l'objectif suivant pour TEAM 1: '{objective_to_use}'"
+        )
+
+        await self._save_global_plan_state(
+            global_plan_id,
+            {
+                "clarified_objective": objective_to_use,
+                "current_supervisor_state": GlobalPlanState.OBJECTIVE_CLARIFIED,
+                "last_question_to_user": None,
+                "user_forced_clarification": True,
+            },
+        )
 
         await self._initiate_team1_planning(global_plan_id, objective_to_use)
         return {
             "status": GlobalPlanState.OBJECTIVE_CLARIFIED,
             "message": "Objectif accepté par l'utilisateur, planification TEAM 1 initiée.",
             "clarified_objective": objective_to_use,
-            "global_plan_id": global_plan_id
+            "global_plan_id": global_plan_id,
         }
-    async def _initiate_team1_planning(self, global_plan_id: str, final_clarified_objective: str):
-        logger.info(f"[GS] Plan '{global_plan_id}': Lancement planification TEAM 1. Objectif: '{final_clarified_objective}'")
-        
+
+    async def _initiate_team1_planning(
+        self, global_plan_id: str, final_clarified_objective: str
+    ):
+        logger.info(
+            f"[GS] Plan '{global_plan_id}': Lancement planification TEAM 1. Objectif: '{final_clarified_objective}'"
+        )
+        await self._update_status(
+            AgentOperationalState.WORKING, f"TEAM1 planification {global_plan_id}"
+        )
+
         current_plan_data = await self._load_global_plan_state(global_plan_id) or {}
         attempt_count = current_plan_data.get("team1_planning_attempts", 0) + 1
-        
-        team1_plan_id = f"team1_{global_plan_id}_attempt{attempt_count}_{uuid.uuid4().hex[:6]}"
 
-        await self._save_global_plan_state(global_plan_id, {
-            "team1_plan_id": team1_plan_id,
-            "team1_planning_attempts": attempt_count,
-            "clarified_objective_for_team1": final_clarified_objective,
-            "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_INITIATED,
-            "team1_status": "INITIATED"
-        })
-        
+        team1_plan_id = (
+            f"team1_{global_plan_id}_attempt{attempt_count}_{uuid.uuid4().hex[:6]}"
+        )
+
+        await self._save_global_plan_state(
+            global_plan_id,
+            {
+                "team1_plan_id": team1_plan_id,
+                "team1_planning_attempts": attempt_count,
+                "clarified_objective_for_team1": final_clarified_objective,
+                "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_INITIATED,
+                "team1_status": "INITIATED",
+            },
+        )
+
         try:
             team1_supervisor = PlanningSupervisorLogic()
-            team1_supervisor.create_new_plan(raw_objective=final_clarified_objective, plan_id=team1_plan_id)
-            logger.info(f"[GS] Plan TEAM 1 '{team1_plan_id}' (structure Firestore) créé pour plan global '{global_plan_id}'.")
-            
-            asyncio.create_task(self._process_team1_plan_fully(team1_supervisor, team1_plan_id, global_plan_id))
-            logger.info(f"[GS] Tâche de fond lancée pour traiter entièrement TEAM 1 '{team1_plan_id}'.")
-        except Exception as e:
-            logger.error(f"[GS] Erreur initiation/lancement TEAM 1 pour '{team1_plan_id}': {e}", exc_info=True)
-            await self._save_global_plan_state(global_plan_id, {
-                "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_FAILED,
-                "team1_status": "FAILED_INITIATION",
-                "error_message": f"Erreur d'initiation TEAM 1: {str(e)}"
-            })
+            team1_supervisor.create_new_plan(
+                raw_objective=final_clarified_objective, plan_id=team1_plan_id
+            )
+            logger.info(
+                f"[GS] Plan TEAM 1 '{team1_plan_id}' (structure Firestore) créé pour plan global '{global_plan_id}'."
+            )
 
-    async def _process_team1_plan_fully(self, team1_supervisor: PlanningSupervisorLogic, team1_plan_id: str, global_plan_id: str):
+            asyncio.create_task(
+                self._process_team1_plan_fully(
+                    team1_supervisor, team1_plan_id, global_plan_id
+                )
+            )
+            logger.info(
+                f"[GS] Tâche de fond lancée pour traiter entièrement TEAM 1 '{team1_plan_id}'."
+            )
+            await self._update_status(
+                AgentOperationalState.IDLE, f"TEAM1 plan {team1_plan_id} lancé"
+            )
+        except Exception as e:
+            logger.error(
+                f"[GS] Erreur initiation/lancement TEAM 1 pour '{team1_plan_id}': {e}",
+                exc_info=True,
+            )
+            await self._save_global_plan_state(
+                global_plan_id,
+                {
+                    "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_FAILED,
+                    "team1_status": "FAILED_INITIATION",
+                    "error_message": f"Erreur d'initiation TEAM 1: {str(e)}",
+                },
+            )
+
+    async def _process_team1_plan_fully(
+        self,
+        team1_supervisor: PlanningSupervisorLogic,
+        team1_plan_id: str,
+        global_plan_id: str,
+    ):
         """
         Appelle team1_supervisor.process_plan en boucle jusqu'à ce que TOUTES les tâches
         du plan TEAM 1 (TaskGraph) soient dans un état terminal.
@@ -392,113 +737,174 @@ class GlobalSupervisorLogic:
         """
         max_cycles_team1 = 20
         check_interval_seconds = 10
-        
-        logger.info(f"[GS] Démarrage du traitement complet et monitoring pour TEAM 1 plan '{team1_plan_id}' (global: '{global_plan_id}')")
-        await self._save_global_plan_state(global_plan_id, {"team1_status": "PROCESSING_ACTIVE"})
+
+        logger.info(
+            f"[GS] Démarrage du traitement complet et monitoring pour TEAM 1 plan '{team1_plan_id}' (global: '{global_plan_id}')"
+        )
+        await self._update_status(
+            AgentOperationalState.WORKING, f"TEAM1 en cours {team1_plan_id}"
+        )
+        await self._save_global_plan_state(
+            global_plan_id, {"team1_status": "PROCESSING_ACTIVE"}
+        )
 
         for i in range(max_cycles_team1):
-            logger.info(f"[GS] Cycle de traitement TEAM 1 N°{i+1}/{max_cycles_team1} pour plan '{team1_plan_id}'")
-            
+            logger.info(
+                f"[GS] Cycle de traitement TEAM 1 N°{i+1}/{max_cycles_team1} pour plan '{team1_plan_id}'"
+            )
+
             await team1_supervisor.process_plan(plan_id=team1_plan_id)
 
-            await asyncio.sleep(check_interval_seconds) 
+            await asyncio.sleep(check_interval_seconds)
 
             team1_task_graph_reader = TaskGraph(plan_id=team1_plan_id)
-            
-            all_team1_tasks_data = await asyncio.to_thread(team1_task_graph_reader.as_dict)
+
+            all_team1_tasks_data = await asyncio.to_thread(
+                team1_task_graph_reader.as_dict
+            )
             nodes_in_team1_plan = all_team1_tasks_data.get("nodes", {})
 
             if not nodes_in_team1_plan:
-                logger.warning(f"[GS] Plan TEAM 1 '{team1_plan_id}': Aucun nœud trouvé dans le TaskGraph. Cela peut être un état initial ou une erreur.")
+                logger.warning(
+                    f"[GS] Plan TEAM 1 '{team1_plan_id}': Aucun nœud trouvé dans le TaskGraph. Cela peut être un état initial ou une erreur."
+                )
                 if i > 1:
-                    logger.error(f"[GS] Plan TEAM 1 '{team1_plan_id}': Aucun nœud après plusieurs cycles. Échec présumé.")
-                    await self._save_global_plan_state(global_plan_id, {
-                        "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_FAILED,
-                        "team1_status": "FAILED_EMPTY_TASK_GRAPH"
-                    })
+                    logger.error(
+                        f"[GS] Plan TEAM 1 '{team1_plan_id}': Aucun nœud après plusieurs cycles. Échec présumé."
+                    )
+                    await self._save_global_plan_state(
+                        global_plan_id,
+                        {
+                            "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_FAILED,
+                            "team1_status": "FAILED_EMPTY_TASK_GRAPH",
+                        },
+                    )
                     return
                 continue
 
-
             non_terminal_tasks_count = 0
             has_any_failed_tasks = False
-            
+
             for task_id, task_data in nodes_in_team1_plan.items():
                 task_state_str = task_data.get("state")
                 if task_state_str not in [
-                    Team1TaskStateEnum.COMPLETED.value, 
-                    Team1TaskStateEnum.FAILED.value, 
+                    Team1TaskStateEnum.COMPLETED.value,
+                    Team1TaskStateEnum.FAILED.value,
                     Team1TaskStateEnum.CANCELLED.value,
-                    Team1TaskStateEnum.UNABLE.value
+                    Team1TaskStateEnum.UNABLE.value,
                 ]:
                     non_terminal_tasks_count += 1
-                
+
                 if task_state_str == Team1TaskStateEnum.FAILED.value:
                     has_any_failed_tasks = True
-            
-            logger.info(f"[GS] Plan TEAM 1 '{team1_plan_id}': {non_terminal_tasks_count} tâches non terminales, y a-t-il des échecs ? {has_any_failed_tasks}.")
+
+            logger.info(
+                f"[GS] Plan TEAM 1 '{team1_plan_id}': {non_terminal_tasks_count} tâches non terminales, y a-t-il des échecs ? {has_any_failed_tasks}."
+            )
 
             if non_terminal_tasks_count == 0:
                 if has_any_failed_tasks:
-                    logger.error(f"[GS] Plan TEAM 1 '{team1_plan_id}' terminé mais avec au moins une tâche en échec.")
-                    await self._save_global_plan_state(global_plan_id, {
-                        "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_FAILED,
-                        "team1_status": "COMPLETED_WITH_FAILURES"
-                    })
+                    logger.error(
+                        f"[GS] Plan TEAM 1 '{team1_plan_id}' terminé mais avec au moins une tâche en échec."
+                    )
+                    await self._save_global_plan_state(
+                        global_plan_id,
+                        {
+                            "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_FAILED,
+                            "team1_status": "COMPLETED_WITH_FAILURES",
+                        },
+                    )
                 else:
-                    logger.info(f"[GS] Plan TEAM 1 '{team1_plan_id}' complété avec succès.")
-                    await self._save_global_plan_state(global_plan_id, {
-                        "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_COMPLETED,
-                        "team1_status": "COMPLETED_SUCCESSFULLY"
-                    })
-                    
-                    logger.info(f"[GS] Plan TEAM 1 complété, initiation de TEAM 2 pour plan global '{global_plan_id}'.")
-                    current_global_plan_data = await self._load_global_plan_state(global_plan_id)
-                    team1_final_plan_text = self._get_final_plan_text_from_team1(team1_plan_id)
+                    logger.info(
+                        f"[GS] Plan TEAM 1 '{team1_plan_id}' complété avec succès."
+                    )
+                    await self._save_global_plan_state(
+                        global_plan_id,
+                        {
+                            "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_COMPLETED,
+                            "team1_status": "COMPLETED_SUCCESSFULLY",
+                        },
+                    )
+
+                    logger.info(
+                        f"[GS] Plan TEAM 1 complété, initiation de TEAM 2 pour plan global '{global_plan_id}'."
+                    )
+                    current_global_plan_data = await self._load_global_plan_state(
+                        global_plan_id
+                    )
+                    team1_final_plan_text = self._get_final_plan_text_from_team1(
+                        team1_plan_id
+                    )
 
                     if team1_final_plan_text:
-                        await self._save_global_plan_state(global_plan_id, {
-                             "current_supervisor_state": "TEAM2_EXECUTION_INITIATING",
-                             "team2_status": "PENDING_INITIALIZATION"
-                        })
+                        await self._save_global_plan_state(
+                            global_plan_id,
+                            {
+                                "current_supervisor_state": "TEAM2_EXECUTION_INITIATING",
+                                "team2_status": "PENDING_INITIALIZATION",
+                            },
+                        )
                         if not self.plan_environment_id:
-                            self.plan_environment_id = await self.environment_manager.create_isolated_environment(global_plan_id)
+                            self.plan_environment_id = await self.environment_manager.create_isolated_environment(
+                                global_plan_id
+                            )
 
                         execution_supervisor = ExecutionSupervisorLogic(
                             global_plan_id=global_plan_id,
                             team1_plan_final_text=team1_final_plan_text,
-                            plan_environment_id=self.plan_environment_id
+                            plan_environment_id=self.plan_environment_id,
                         )
-                        asyncio.create_task(self._run_and_monitor_team2_execution(execution_supervisor, global_plan_id))
+                        asyncio.create_task(
+                            self._run_and_monitor_team2_execution(
+                                execution_supervisor, global_plan_id
+                            )
+                        )
                     else:
-                        logger.error(f"[GS] Impossible de récupérer le texte final du plan TEAM 1 '{team1_plan_id}'. TEAM 2 ne sera pas lancée.")
-                        await self._save_global_plan_state(global_plan_id, {
-                            "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_COMPLETED,
-                            "team2_status": "NOT_STARTED_NO_PLAN_TEXT",
-                            "error_message": "TEAM 1 final plan text could not be retrieved."
-                        })
-                return                    
+                        logger.error(
+                            f"[GS] Impossible de récupérer le texte final du plan TEAM 1 '{team1_plan_id}'. TEAM 2 ne sera pas lancée."
+                        )
+                        await self._save_global_plan_state(
+                            global_plan_id,
+                            {
+                                "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_COMPLETED,
+                                "team2_status": "NOT_STARTED_NO_PLAN_TEXT",
+                                "error_message": "TEAM 1 final plan text could not be retrieved.",
+                            },
+                        )
+                return
 
             if has_any_failed_tasks:
                 active_tasks_count = 0
                 for task_data_inner in nodes_in_team1_plan.values():
-                    if task_data_inner.get("state") in [Team1TaskStateEnum.SUBMITTED.value, Team1TaskStateEnum.WORKING.value]:
-                        active_tasks_count +=1
+                    if task_data_inner.get("state") in [
+                        Team1TaskStateEnum.SUBMITTED.value,
+                        Team1TaskStateEnum.WORKING.value,
+                    ]:
+                        active_tasks_count += 1
                         break
                 if active_tasks_count == 0:
-                    logger.error(f"[GS] Plan TEAM 1 '{team1_plan_id}' a des tâches en échec et aucune tâche active restante.")
-                    await self._save_global_plan_state(global_plan_id, {
-                        "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_FAILED,
-                        "team1_status": "FAILED_WITH_NO_ACTIVE_TASKS"
-                    })
+                    logger.error(
+                        f"[GS] Plan TEAM 1 '{team1_plan_id}' a des tâches en échec et aucune tâche active restante."
+                    )
+                    await self._save_global_plan_state(
+                        global_plan_id,
+                        {
+                            "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_FAILED,
+                            "team1_status": "FAILED_WITH_NO_ACTIVE_TASKS",
+                        },
+                    )
                     return
 
-
-        logger.warning(f"[GS] Plan TEAM 1 '{team1_plan_id}' n'a pas atteint un état terminal complet après {max_cycles_team1} cycles de traitement/vérification.")
-        await self._save_global_plan_state(global_plan_id, {
-            "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_FAILED,
-            "team1_status": "FAILED_TIMEOUT_MAX_CYCLES"
-        })
+        logger.warning(
+            f"[GS] Plan TEAM 1 '{team1_plan_id}' n'a pas atteint un état terminal complet après {max_cycles_team1} cycles de traitement/vérification."
+        )
+        await self._save_global_plan_state(
+            global_plan_id,
+            {
+                "current_supervisor_state": GlobalPlanState.TEAM1_PLANNING_FAILED,
+                "team1_status": "FAILED_TIMEOUT_MAX_CYCLES",
+            },
+        )
 
     def _get_final_plan_text_from_team1(self, team1_plan_id: str) -> Optional[str]:
         """
@@ -506,64 +912,112 @@ class GlobalSupervisorLogic:
         Ceci est une placeholder - la logique exacte dépendra de comment/où ce texte est stocké.
         Probablement l'artefact de la dernière tâche de validation réussie du TaskGraph de TEAM 1.
         """
-        logger.info(f"[GS] Tentative de récupération du texte final du plan TEAM 1 '{team1_plan_id}'.")
-        
+        logger.info(
+            f"[GS] Tentative de récupération du texte final du plan TEAM 1 '{team1_plan_id}'."
+        )
+
         team1_graph_manager = TaskGraph(plan_id=team1_plan_id)
         graph_data = team1_graph_manager.as_dict()
         nodes = graph_data.get("nodes", {})
-        
+
         validation_tasks_completed = []
         for task_id, node_data in nodes.items():
-            if node_data.get("assigned_agent") == "ValidatorAgentServer" and \
-               node_data.get("state") == "completed" and \
-               isinstance(node_data.get("artifact_ref"), dict):
+            if (
+                node_data.get("assigned_agent") == "ValidatorAgentServer"
+                and node_data.get("state") == "completed"
+                and isinstance(node_data.get("artifact_ref"), dict)
+            ):
                 artifact_content = node_data.get("artifact_ref")
                 if artifact_content.get("validation_status") == "approved":
-                    validation_tasks_completed.append({
-                        "timestamp": node_data.get("history", [{}])[-1].get("timestamp", ""),
-                        "plan_text": artifact_content.get("final_plan", artifact_content.get("evaluated_plan"))
-                    })
-        
+                    validation_tasks_completed.append(
+                        {
+                            "timestamp": node_data.get("history", [{}])[-1].get(
+                                "timestamp", ""
+                            ),
+                            "plan_text": artifact_content.get(
+                                "final_plan", artifact_content.get("evaluated_plan")
+                            ),
+                        }
+                    )
+
         if not validation_tasks_completed:
-            logger.warning(f"[GS] Aucune tâche de validation approuvée trouvée pour TEAM 1 '{team1_plan_id}'.")
+            logger.warning(
+                f"[GS] Aucune tâche de validation approuvée trouvée pour TEAM 1 '{team1_plan_id}'."
+            )
             return None
-            
+
         validation_tasks_completed.sort(key=lambda x: x["timestamp"], reverse=True)
         final_plan_text = validation_tasks_completed[0].get("plan_text")
 
         if final_plan_text:
-            logger.info(f"[GS] Texte final du plan TEAM 1 récupéré pour '{team1_plan_id}'.")
+            logger.info(
+                f"[GS] Texte final du plan TEAM 1 récupéré pour '{team1_plan_id}'."
+            )
             return final_plan_text
         else:
-            logger.warning(f"[GS] Texte final du plan TEAM 1 non trouvé dans l'artefact de validation pour '{team1_plan_id}'.")
+            logger.warning(
+                f"[GS] Texte final du plan TEAM 1 non trouvé dans l'artefact de validation pour '{team1_plan_id}'."
+            )
             return None
 
-
-    async def _run_and_monitor_team2_execution(self, execution_supervisor: ExecutionSupervisorLogic, global_plan_id: str):
-        logger.info(f"[GS] Lancement du traitement complet de TEAM 2 pour plan global '{global_plan_id}' (exec_id: {execution_supervisor.execution_plan_id})")
-        await self._save_global_plan_state(global_plan_id, {
-            "current_supervisor_state": "TEAM2_EXECUTION_IN_PROGRESS",
-            "team2_execution_plan_id": execution_supervisor.execution_plan_id,
-            "team2_status": "RUNNING"
-        })
+    async def _run_and_monitor_team2_execution(
+        self, execution_supervisor: ExecutionSupervisorLogic, global_plan_id: str
+    ):
+        logger.info(
+            f"[GS] Lancement du traitement complet de TEAM 2 pour plan global '{global_plan_id}' (exec_id: {execution_supervisor.execution_plan_id})"
+        )
+        await self._update_status(
+            AgentOperationalState.WORKING, f"TEAM2 exécution {global_plan_id}"
+        )
+        await self._save_global_plan_state(
+            global_plan_id,
+            {
+                "current_supervisor_state": "TEAM2_EXECUTION_IN_PROGRESS",
+                "team2_execution_plan_id": execution_supervisor.execution_plan_id,
+                "team2_status": "RUNNING",
+            },
+        )
         try:
             await execution_supervisor.run_full_execution()
-            
-            final_exec_status = execution_supervisor.task_graph.as_dict().get("overall_status", "UNKNOWN")
-            logger.info(f"[GS] TEAM 2 pour plan global '{global_plan_id}' terminée. Statut final exécution: {final_exec_status}")
-            
-            new_global_state = "TEAM2_EXECUTION_COMPLETED" if "COMPLETED" in final_exec_status.upper() else "TEAM2_EXECUTION_FAILED"
-            await self._save_global_plan_state(global_plan_id, {
-                "current_supervisor_state": new_global_state,
-                "team2_status": final_exec_status
-            })
+
+            final_exec_status = execution_supervisor.task_graph.as_dict().get(
+                "overall_status", "UNKNOWN"
+            )
+            logger.info(
+                f"[GS] TEAM 2 pour plan global '{global_plan_id}' terminée. Statut final exécution: {final_exec_status}"
+            )
+
+            new_global_state = (
+                "TEAM2_EXECUTION_COMPLETED"
+                if "COMPLETED" in final_exec_status.upper()
+                else "TEAM2_EXECUTION_FAILED"
+            )
+            await self._save_global_plan_state(
+                global_plan_id,
+                {
+                    "current_supervisor_state": new_global_state,
+                    "team2_status": final_exec_status,
+                },
+            )
+            await self._update_status(
+                AgentOperationalState.IDLE, f"TEAM2 terminée {global_plan_id}"
+            )
         except Exception as e:
-            logger.error(f"[GS] Erreur majeure durant l'exécution de TEAM 2 pour '{global_plan_id}': {e}", exc_info=True)
-            await self._save_global_plan_state(global_plan_id, {
-                "current_supervisor_state": "TEAM2_EXECUTION_FAILED",
-                "team2_status": "SUPERVISOR_ERROR",
-                "error_message": f"Erreur superviseur TEAM 2: {str(e)}"
-            })
+            logger.error(
+                f"[GS] Erreur majeure durant l'exécution de TEAM 2 pour '{global_plan_id}': {e}",
+                exc_info=True,
+            )
+            await self._save_global_plan_state(
+                global_plan_id,
+                {
+                    "current_supervisor_state": "TEAM2_EXECUTION_FAILED",
+                    "team2_status": "SUPERVISOR_ERROR",
+                    "error_message": f"Erreur superviseur TEAM 2: {str(e)}",
+                },
+            )
+            await self._update_status(
+                AgentOperationalState.ERROR, f"TEAM2 erreur {global_plan_id}"
+            )
 
     async def continue_team2_execution(self, global_plan_id: str) -> Dict[str, Any]:
         """Reprend l'exécution TEAM 2 pour un plan global existant."""
@@ -603,24 +1057,36 @@ class GlobalSupervisorLogic:
             global_plan_id=global_plan_id,
             team1_plan_final_text=team1_text,
             execution_plan_id=exec_plan_id,
-            plan_environment_id=self.plan_environment_id
-
+            plan_environment_id=self.plan_environment_id,
         )
 
+        await self._update_status(
+            AgentOperationalState.WORKING, f"Reprise TEAM2 {global_plan_id}"
+        )
         await exec_supervisor.continue_execution()
+        await self._update_status(
+            AgentOperationalState.IDLE, f"Reprise TEAM2 terminée {global_plan_id}"
+        )
 
-        final_exec_status = exec_supervisor.task_graph.as_dict().get("overall_status", "UNKNOWN")
+        final_exec_status = exec_supervisor.task_graph.as_dict().get(
+            "overall_status", "UNKNOWN"
+        )
 
         new_state = (
             "TEAM2_EXECUTION_COMPLETED"
             if final_exec_status.startswith("EXECUTION_COMPLETED")
-            else current_plan.get("current_supervisor_state", "TEAM2_EXECUTION_IN_PROGRESS")
+            else current_plan.get(
+                "current_supervisor_state", "TEAM2_EXECUTION_IN_PROGRESS"
+            )
         )
 
-        await self._save_global_plan_state(global_plan_id, {
-            "current_supervisor_state": new_state,
-            "team2_status": final_exec_status,
-        })
+        await self._save_global_plan_state(
+            global_plan_id,
+            {
+                "current_supervisor_state": new_state,
+                "team2_status": final_exec_status,
+            },
+        )
 
         return {
             "status": "team2_execution_resumed",
@@ -628,36 +1094,62 @@ class GlobalSupervisorLogic:
             "global_plan_id": global_plan_id,
             "current_supervisor_state": new_state,
         }
+
+
 async def main_test_global_supervisor():
     supervisor = GlobalSupervisorLogic()
     if not supervisor.db:
         logger.error("Échec initialisation Firestore. Arrêt test.")
         return
 
-    
     objective = "Planifier et exécuter le développement d'une petite application CLI de visualisation de Fractale standard en Python, une application éducative pour les ado."
     user_id_for_test = f"test_user_{uuid.uuid4().hex[:6]}"
 
-    logger.info(f"\n--- TEST COMPLET GlobalSupervisor: Objectif initial = '{objective}' ---")
-    
-    response_step1 = await supervisor.start_new_global_plan(raw_objective=objective, user_id=user_id_for_test)
+    logger.info(
+        f"\n--- TEST COMPLET GlobalSupervisor: Objectif initial = '{objective}' ---"
+    )
+
+    response_step1 = await supervisor.start_new_global_plan(
+        raw_objective=objective, user_id=user_id_for_test
+    )
     global_plan_id = response_step1.get("global_plan_id")
-    logger.info(f"Réponse Étape 1 (start_new_global_plan pour '{global_plan_id}'): {json.dumps(response_step1, indent=2, ensure_ascii=False)}")
+    logger.info(
+        f"Réponse Étape 1 (start_new_global_plan pour '{global_plan_id}'): {json.dumps(response_step1, indent=2, ensure_ascii=False)}"
+    )
     if not global_plan_id:
         logger.error("Aucun global_plan_id retourné. Arrêt du test.")
         return
-    
+
     current_state_s1 = await supervisor._load_global_plan_state(global_plan_id)
-    if current_state_s1 and current_state_s1.get("current_supervisor_state") == GlobalPlanState.CLARIFICATION_PENDING_USER_INPUT:
-        logger.info(f"Clarification demandée, réponse simulée pour '{global_plan_id}'...")
+    if (
+        current_state_s1
+        and current_state_s1.get("current_supervisor_state")
+        == GlobalPlanState.CLARIFICATION_PENDING_USER_INPUT
+    ):
+        logger.info(
+            f"Clarification demandée, réponse simulée pour '{global_plan_id}'..."
+        )
         simulated_user_response = "Oui, la proposition me convient, les fonctionnalités de base sont suffisantes pour un CLI."
-        await supervisor.process_user_clarification_response(global_plan_id, simulated_user_response)
+        await supervisor.process_user_clarification_response(
+            global_plan_id, simulated_user_response
+        )
         current_state_s1 = await supervisor._load_global_plan_state(global_plan_id)
 
-    if not (current_state_s1 and current_state_s1.get("current_supervisor_state") == GlobalPlanState.OBJECTIVE_CLARIFIED):
-        logger.info(f"Objectif non clarifié, forçage de l'acceptation pour '{global_plan_id}' pour passer à TEAM 1...")
-        await supervisor.accept_objective_and_initiate_team1(global_plan_id, current_state_s1.get("tentatively_enriched_objective_from_agent", objective))
-    
+    if not (
+        current_state_s1
+        and current_state_s1.get("current_supervisor_state")
+        == GlobalPlanState.OBJECTIVE_CLARIFIED
+    ):
+        logger.info(
+            f"Objectif non clarifié, forçage de l'acceptation pour '{global_plan_id}' pour passer à TEAM 1..."
+        )
+        await supervisor.accept_objective_and_initiate_team1(
+            global_plan_id,
+            current_state_s1.get(
+                "tentatively_enriched_objective_from_agent", objective
+            ),
+        )
+
     logger.info(f"\n--- Attente de la complétion de TEAM 1 pour '{global_plan_id}' ---")
     max_wait_cycles_team1 = 25
     team1_completed_successfully = False
@@ -666,23 +1158,31 @@ async def main_test_global_supervisor():
         current_global_state = await supervisor._load_global_plan_state(global_plan_id)
         supervisor_state = current_global_state.get("current_supervisor_state")
         team1_status = current_global_state.get("team1_status")
-        logger.info(f"Cycle d'attente TEAM 1 ({cycle+1}/{max_wait_cycles_team1}) pour '{global_plan_id}': État Global = {supervisor_state}, Statut TEAM 1 = {team1_status}")
+        logger.info(
+            f"Cycle d'attente TEAM 1 ({cycle+1}/{max_wait_cycles_team1}) pour '{global_plan_id}': État Global = {supervisor_state}, Statut TEAM 1 = {team1_status}"
+        )
 
         if supervisor_state == GlobalPlanState.TEAM1_PLANNING_COMPLETED:
             logger.info(f"TEAM 1 COMPLÉTÉE avec succès pour '{global_plan_id}'.")
             team1_completed_successfully = True
-            
+
         elif supervisor_state == GlobalPlanState.TEAM1_PLANNING_FAILED:
             logger.error(f"TEAM 1 ÉCHOUÉE pour '{global_plan_id}'. Arrêt du test.")
             return
-    
+
     if not team1_completed_successfully:
-        logger.error(f"TEAM 1 n'a pas terminé avec succès après {max_wait_cycles_team1} cycles pour '{global_plan_id}'.")
+        logger.error(
+            f"TEAM 1 n'a pas terminé avec succès après {max_wait_cycles_team1} cycles pour '{global_plan_id}'."
+        )
         final_state_doc_error = await supervisor._load_global_plan_state(global_plan_id)
-        logger.info(f"État final (erreur TEAM 1) pour '{global_plan_id}': {json.dumps(final_state_doc_error, indent=2, ensure_ascii=False)}")
+        logger.info(
+            f"État final (erreur TEAM 1) pour '{global_plan_id}': {json.dumps(final_state_doc_error, indent=2, ensure_ascii=False)}"
+        )
         return
 
-    logger.info(f"\n--- Vérification de l'initiation et de la décomposition par TEAM 2 pour '{global_plan_id}' ---")
+    logger.info(
+        f"\n--- Vérification de l'initiation et de la décomposition par TEAM 2 pour '{global_plan_id}' ---"
+    )
     max_wait_cycles_team2_decomp = 10
     team2_decomposition_done = False
     execution_plan_id_for_team2 = None
@@ -691,50 +1191,80 @@ async def main_test_global_supervisor():
 
     for cycle in range(max_overall_cycles):
         await asyncio.sleep(10)
-        current_global_plan_doc = await supervisor._load_global_plan_state(global_plan_id)
+        current_global_plan_doc = await supervisor._load_global_plan_state(
+            global_plan_id
+        )
         if not current_global_plan_doc:
-            logger.error(f"Impossible de charger l'état du plan global '{global_plan_id}'. Arrêt.")
+            logger.error(
+                f"Impossible de charger l'état du plan global '{global_plan_id}'. Arrêt."
+            )
             break
 
-        current_supervisor_state = current_global_plan_doc.get("current_supervisor_state")
+        current_supervisor_state = current_global_plan_doc.get(
+            "current_supervisor_state"
+        )
         team1_status = current_global_plan_doc.get("team1_status")
         team2_status = current_global_plan_doc.get("team2_status")
         team1_plan_id = current_global_plan_doc.get("team1_plan_id", "N/A")
         team2_exec_id = current_global_plan_doc.get("team2_execution_plan_id", "N/A")
 
-        logger.info(f"Cycle Global {cycle+1}/{max_overall_cycles} pour '{global_plan_id}': "
-                    f"État Sup Glob='{current_supervisor_state}', T1 Stat='{team1_status}' (ID:{team1_plan_id}), T2 Stat='{team2_status}' (ID:{team2_exec_id})")
+        logger.info(
+            f"Cycle Global {cycle+1}/{max_overall_cycles} pour '{global_plan_id}': "
+            f"État Sup Glob='{current_supervisor_state}', T1 Stat='{team1_status}' (ID:{team1_plan_id}), T2 Stat='{team2_status}' (ID:{team2_exec_id})"
+        )
 
         if current_supervisor_state == GlobalPlanState.TEAM2_EXECUTION_COMPLETED:
             if team2_status == "EXECUTION_COMPLETED_SUCCESSFULLY":
-                logger.info(f"🎉 Plan Global '{global_plan_id}' COMPLÉTÉ AVEC SUCCÈS (TEAM 1 & TEAM 2 OK).")
+                logger.info(
+                    f"🎉 Plan Global '{global_plan_id}' COMPLÉTÉ AVEC SUCCÈS (TEAM 1 & TEAM 2 OK)."
+                )
             else:
-                logger.warning(f"🏁 Plan Global '{global_plan_id}' : TEAM 2 terminée mais avec statut '{team2_status}'.")
+                logger.warning(
+                    f"🏁 Plan Global '{global_plan_id}' : TEAM 2 terminée mais avec statut '{team2_status}'."
+                )
             final_plan_status_reached = True
             break
-        elif current_supervisor_state == GlobalPlanState.TEAM1_PLANNING_FAILED or \
-             current_supervisor_state == GlobalPlanState.TEAM2_EXECUTION_FAILED or \
-             current_supervisor_state == GlobalPlanState.FAILED_MAX_CLARIFICATION_ATTEMPTS or \
-             current_supervisor_state == GlobalPlanState.FAILED_AGENT_ERROR:
-            logger.error(f"❌ Échec du Plan Global '{global_plan_id}'. État: {current_supervisor_state}.")
+        elif (
+            current_supervisor_state == GlobalPlanState.TEAM1_PLANNING_FAILED
+            or current_supervisor_state == GlobalPlanState.TEAM2_EXECUTION_FAILED
+            or current_supervisor_state
+            == GlobalPlanState.FAILED_MAX_CLARIFICATION_ATTEMPTS
+            or current_supervisor_state == GlobalPlanState.FAILED_AGENT_ERROR
+        ):
+            logger.error(
+                f"❌ Échec du Plan Global '{global_plan_id}'. État: {current_supervisor_state}."
+            )
             final_plan_status_reached = True
             break
-        
+
         if cycle == max_overall_cycles - 1:
-            logger.error(f"TIMEOUT: Le plan global '{global_plan_id}' n'a pas atteint un état final après {max_overall_cycles} cycles.")
+            logger.error(
+                f"TIMEOUT: Le plan global '{global_plan_id}' n'a pas atteint un état final après {max_overall_cycles} cycles."
+            )
             break
 
     final_doc = await supervisor._load_global_plan_state(global_plan_id)
-    logger.info(f"\n--- État final complet du document Firestore pour Global Plan ID '{global_plan_id}' ---")
+    logger.info(
+        f"\n--- État final complet du document Firestore pour Global Plan ID '{global_plan_id}' ---"
+    )
     logger.info(f"{json.dumps(final_doc, indent=2, ensure_ascii=False)}")
     logger.info(f"--- FIN DU TEST pour Global Plan ID '{global_plan_id}' ---")
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-    logging.getLogger("src.orchestrators.global_supervisor_logic").setLevel(logging.DEBUG)
-    logging.getLogger("src.orchestrators.execution_supervisor_logic").setLevel(logging.DEBUG)
-    logging.getLogger("src.shared.execution_task_graph_management").setLevel(logging.DEBUG) 
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    logging.getLogger("src.orchestrators.global_supervisor_logic").setLevel(
+        logging.DEBUG
+    )
+    logging.getLogger("src.orchestrators.execution_supervisor_logic").setLevel(
+        logging.DEBUG
+    )
+    logging.getLogger("src.shared.execution_task_graph_management").setLevel(
+        logging.DEBUG
+    )
     logging.getLogger("src.agents.decomposition_agent.logic").setLevel(logging.DEBUG)
     logging.getLogger("src.agents.research_agent.logic").setLevel(logging.DEBUG)
     logging.getLogger("src.agents.development_agent.logic").setLevel(logging.DEBUG)


### PR DESCRIPTION
## Summary
- track operational status in execution and global supervisors
- send status updates to the GRA using `/agent_status_update`
- notify at major execution and planning phases

## Testing
- `black src/orchestrators/execution_supervisor_logic.py src/orchestrators/global_supervisor_logic.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kubernetes')*

------
https://chatgpt.com/codex/tasks/task_e_68557ef99768832dbfc62a999a1edb38