### PR TITLE
Fix supervisor stats and group display

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -267,17 +267,18 @@ function AgentStatusBar({ agents, graHealth, stats }) {
       </div>
     </div>
   );
-    return (
-      <div className="agents-container">
-        {graCard}
-        {agentList.map(a => {
+  const supervisorsNames = ['GlobalSupervisorLogic', 'ExecutionSupervisorLogic'];
+  const supervisors = agentList.filter(a => supervisorsNames.includes(a.name));
+  const otherAgents = agentList.filter(a => !supervisorsNames.includes(a.name));
+
+  const renderCard = a => {
           const { className, icon } = getStatusInfo(a.health_status);
           const stateText = a.health_status?.state || 'Offline';
           const tooltip = `Skills: ${(a.skills || []).join(', ')}\n` +
                           `Internal: ${a.internal_url}\n` +
                           (a.public_url ? `URL: ${a.public_url}\n` : '') +
                           (a.health_status?.current_task_id ? `Task: ${a.health_status.current_task_id}` : 'No active task');
-          
+
           return (
             <div key={a.name} className="agent-card" title={tooltip}>
               <div className="agent-header">
@@ -295,7 +296,17 @@ function AgentStatusBar({ agents, graHealth, stats }) {
               </div>
             </div>
           );
-        })}
+        };
+
+  return (
+      <div className="agents-container">
+        <div className="agents-group">
+          {graCard}
+          {supervisors.map(renderCard)}
+        </div>
+        <div className="agents-group">
+          {otherAgents.map(renderCard)}
+        </div>
       </div>
     );
 }

--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -121,9 +121,14 @@ input {
 
 .agents-container {
   display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.agents-group {
+  display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-bottom: 1rem;
 }
 
 .agent-card {

--- a/src/orchestrators/global_supervisor_logic.py
+++ b/src/orchestrators/global_supervisor_logic.py
@@ -18,6 +18,7 @@ from src.orchestrators.planning_supervisor_logic import PlanningSupervisorLogic
 from src.shared.task_graph_management import TaskGraph, TaskState as Team1TaskStateEnum
 from src.orchestrators.execution_supervisor_logic import ExecutionSupervisorLogic
 from src.shared.execution_task_graph_management import ExecutionTaskGraph
+from src.shared.stats_utils import update_agent_stats
 
 from a2a.types import Task, TaskState, TextPart
 
@@ -1002,6 +1003,10 @@ class GlobalSupervisorLogic:
             await self._update_status(
                 AgentOperationalState.IDLE, f"TEAM2 terminée {global_plan_id}"
             )
+
+            success = final_exec_status.startswith("EXECUTION_COMPLETED")
+            update_agent_stats("ExecutionSupervisorLogic", success)
+            update_agent_stats("GlobalSupervisorLogic", success)
         except Exception as e:
             logger.error(
                 f"[GS] Erreur majeure durant l'exécution de TEAM 2 pour '{global_plan_id}': {e}",
@@ -1018,6 +1023,8 @@ class GlobalSupervisorLogic:
             await self._update_status(
                 AgentOperationalState.ERROR, f"TEAM2 erreur {global_plan_id}"
             )
+            update_agent_stats("ExecutionSupervisorLogic", False)
+            update_agent_stats("GlobalSupervisorLogic", False)
 
     async def continue_team2_execution(self, global_plan_id: str) -> Dict[str, Any]:
         """Reprend l'exécution TEAM 2 pour un plan global existant."""

--- a/src/shared/stats_utils.py
+++ b/src/shared/stats_utils.py
@@ -1,0 +1,28 @@
+import logging
+from firebase_admin import firestore
+from .firebase_init import db
+
+logger = logging.getLogger(__name__)
+
+def update_agent_stats(agent_name: str, success: bool):
+    """Increment success or failure counters for the given agent."""
+    if not db:
+        logger.error(
+            "Client Firestore (db) non initialisé, impossible de mettre à jour les stats."
+        )
+        return
+    try:
+        stats_ref = db.collection("agent_stats").document(agent_name)
+        field_to_update = (
+            {"tasks_completed": firestore.Increment(1)}
+            if success
+            else {"tasks_failed": firestore.Increment(1)}
+        )
+        stats_ref.set(field_to_update, merge=True)
+        logger.info(
+            f"Statistiques mises à jour pour {agent_name}: +1 tâche {'complétée' if success else 'échouée'}."
+        )
+    except Exception as e:
+        logger.error(
+            f"Impossible de mettre à jour les statistiques pour {agent_name}: {e}"
+        )


### PR DESCRIPTION
## Summary
- expose a `stats_utils.update_agent_stats` helper
- count completed/failed tasks for `GlobalSupervisorLogic` and `ExecutionSupervisorLogic`
- show supervisors grouped separately in the React dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855c2a85efc832db7a4dc71ea47df07