### PR TITLE
Add file preview in React dashboard

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -453,6 +453,40 @@ input {
 .file-browser .file-actions button {
   margin-left: 0.5rem;
 }
+
+.file-preview-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 5000;
+}
+
+.file-preview {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  max-width: 80%;
+  max-height: 80%;
+  overflow: auto;
+  padding: 1rem;
+  position: relative;
+}
+.file-preview pre {
+  margin: 0;
+  white-space: pre-wrap;
+}
+.file-preview-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  font-weight: bold;
+}
 .error-message {
   color: var(--error-text);
   font-weight: bold;


### PR DESCRIPTION
## Summary
- enable previewing files from the React file explorer
- style overlay for file preview modal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: kubernetes)*

------
https://chatgpt.com/codex/tasks/task_e_6855db28caf0832d88fa54d86afd75e8