### PR TITLE
Fix agent stats counters

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -287,12 +287,21 @@ function AgentStatusBar({ agents, graHealth, stats }) {
               </div>
               <div className="agent-timestamp">{a.timestamp ? new Date(a.timestamp).toLocaleString() : 'N/A'}</div>
               <div className="agent-metrics">
-                <div className="metric-tile success">
-                  {statsMap[a.name.replace('AgentServer', 'AgentExecutor')]?.tasks_completed ?? 0}
-                </div>
-                <div className="metric-tile fail">
-                  {statsMap[a.name.replace('AgentServer', 'AgentExecutor')]?.tasks_failed ?? 0}
-                </div>
+                {(() => {
+                  const statKey = a.name;
+                  const altKey = a.name.replace('AgentServer', 'AgentExecutor');
+                  const stat = statsMap[statKey] || statsMap[altKey];
+                  return (
+                    <>
+                      <div className="metric-tile success">
+                        {stat?.tasks_completed ?? 0}
+                      </div>
+                      <div className="metric-tile fail">
+                        {stat?.tasks_failed ?? 0}
+                      </div>
+                    </>
+                  );
+                })()}
               </div>
             </div>
           );


### PR DESCRIPTION
## Summary
- fix lookup of agent stats in React dashboard by checking raw agent name first

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'a2a.client')*

------
https://chatgpt.com/codex/tasks/task_e_6855e67b9428832d91ddda519c1651f2