### PR TITLE
Remove N/A timestamp placeholder

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -285,7 +285,7 @@ function AgentStatusBar({ agents, graHealth, stats }) {
                 <div className="agent-name">{a.name.replace('AgentServer', '')}</div>
                 <div className={className}>{icon} {stateText}</div>
               </div>
-              <div className="agent-timestamp">{a.timestamp ? new Date(a.timestamp).toLocaleString() : 'N/A'}</div>
+              <div className="agent-timestamp">{a.timestamp ? new Date(a.timestamp).toLocaleString() : '–'}</div>
               <div className="agent-metrics">
                 {(() => {
                   const statKey = a.name;


### PR DESCRIPTION
## Summary
- display a dash when an agent has no registration timestamp

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kubernetes')*

------
https://chatgpt.com/codex/tasks/task_e_6856019957c0832da15d7cf4fba86f5a