### PR TITLE
Update README with new environment and status info

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ OrchestrAI turns any vague user goal into a detailed action plan and concrete de
 - **Composable & extensible**: Add new agents or skills anytime—just register with the GRA and they are orchestrated automatically.
 - **A2A protocol & Google ADK compliant**: Ensures interoperability and future-proofing.
 - **Full audit trail**: Every decision, correction and outcome is persisted in Firestore for transparency.
-- **Isolated dev environments**: Generated code runs in Kubernetes pods managed by the `EnvironmentManager` for safety (see `docs/environment_manager.md`).
+- **Isolated dev environments**: Generated code runs in Kubernetes pods managed by the `EnvironmentManager` for safety (see `docs/environment_manager.md`). Environment metadata lives in Firestore and, when no dedicated pod can be created, the manager reuses a shared `exec_default` environment (see `scripts/create_fallback_environment.py`).
+- **Real-time agent status**: The GRA exposes `/gra_status` and `/ws/status` endpoints so the dashboard can display each agent's operational state (Idle, Busy, Working, etc.).
 
 ---
 
@@ -340,6 +341,8 @@ Several helper scripts are provided for deployment and maintenance tasks.
 - `run_gra_docker.sh` – start the GRA container locally with credentials.
 - `setup_ssh_key_github.sh` – configure an SSH key for GitHub and update the remote.
 - `test_droit.sh` – grant persistent volume claim permissions on Kubernetes.
+- `create_PODimage_and_deploy.sh` – build a `python-devtools` image for isolated environments and push it to GCR.
+- `scripts/create_fallback_environment.py` – create the shared fallback pod used when environment creation fails.
 - `scripts/deploy_test.sh` – deploy agents using an existing GKE cluster and connector.
 - `scripts/grant_agent_permissions.sh` – allow inter-service Cloud Run invocations.
 - `scripts/grant_gke_permissions_to_cloudrun_sa.sh` – give the Cloud Run service account access to GKE.


### PR DESCRIPTION
## Summary
- document fallback environment and real-time status in feature list
- reference scripts to build execution image and create fallback env

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kubernetes')*

------
https://chatgpt.com/codex/tasks/task_e_68560b4d4484832da74791d9524a546a