### PR TITLE
Improve task result tracing

### DIFF
--- a/src/services/gra/server.py
+++ b/src/services/gra/server.py
@@ -1014,6 +1014,8 @@ async def update_agent_status(status_update: Dict[str, Any]):
     if not agent_name:
         return {"status": "error", "message": "agent name is missing"}
 
+    logger.debug(f"[GRA] Update reçu de {agent_name}: {status_update}")
+
     # Récupérer les infos existantes de l'agent dans le cache, ou un dict vide
     current_agent_info = agent_statuses.get(agent_name, {})
 


### PR DESCRIPTION
## Summary
- add extra debug logging in ExecutionSupervisorLogic to capture raw A2A results and mark failed tasks
- log incoming `/agent_status_update` payloads in the GRA server

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'a2a.client')*

------
https://chatgpt.com/codex/tasks/task_e_68566f64b944832dbdcf6b2aeaebad02