### PR TITLE
Add log viewer in React dashboard

### DIFF
--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -515,6 +515,36 @@ input {
   cursor: pointer;
   font-weight: bold;
 }
+.log-modal-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 5000;
+}
+
+.log-modal {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  max-width: 80%;
+  max-height: 80%;
+  overflow: auto;
+  padding: 1rem;
+  position: relative;
+}
+
+.log-modal-close {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  cursor: pointer;
+  font-weight: bold;
+}
 .error-message {
   color: var(--error-text);
   font-weight: bold;


### PR DESCRIPTION
## Summary
- add `onViewLogs` callback in `AgentStatusBar`
- show button in each agent card to open logs
- fetch logs from agent API and display in new modal
- style modal overlay in CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: kubernetes, httpx, vertexai)*

------
https://chatgpt.com/codex/tasks/task_e_6856c2464da8832dbe227ce5703df475