### PR TITLE
Add log endpoint in all agent servers

### DIFF
--- a/src/agents/decomposition_agent/server.py
+++ b/src/agents/decomposition_agent/server.py
@@ -13,12 +13,22 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.responses import JSONResponse
 
+# --- 1. Import du nouveau handler ---
+from src.shared.log_handler import InMemoryLogHandler
+
 from src.shared.service_discovery import get_gra_base_url, register_self_with_gra
 from .executor import DecompositionAgentExecutor
 from .logic import AGENT_SKILL_DECOMPOSE_EXECUTION_PLAN
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+
+# --- 2. Initialisation et configuration du logging ---
+in_memory_log_handler = InMemoryLogHandler(maxlen=200)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+in_memory_log_handler.setFormatter(formatter)
+logging.getLogger().addHandler(in_memory_log_handler)
+logging.getLogger().setLevel(logging.INFO)
 
 AGENT_NAME = "DecompositionAgentServer"
 AGENT_SKILLS_LIST = [AGENT_SKILL_DECOMPOSE_EXECUTION_PLAN]
@@ -49,6 +59,11 @@ def get_decomposition_agent_card() -> AgentCard:
 agent_executor = DecompositionAgentExecutor()
 task_store = InMemoryTaskStore()
 request_handler = DefaultRequestHandler(agent_executor=agent_executor, task_store=task_store)
+
+# --- 3. Création de l'endpoint /logs ---
+async def logs_endpoint(request):
+    """Retourne les dernières lignes de log de l'agent."""
+    return JSONResponse(content=in_memory_log_handler.get_logs())
 
 @contextlib.asynccontextmanager
 async def lifespan(app_param: Starlette):
@@ -98,9 +113,14 @@ def create_app_instance() -> Starlette:
     app.router.routes.append(
         Route("/status", endpoint=status_endpoint, methods=["GET"])
     )
- 
+
+    # --- 4. Ajout de la nouvelle route ---
+    app.router.routes.append(
+        Route("/logs", endpoint=logs_endpoint, methods=["GET"])
+    )
+
     app.router.lifespan_context = lifespan
-    
+
     return app
 
 app = create_app_instance()

--- a/src/agents/development_agent/server.py
+++ b/src/agents/development_agent/server.py
@@ -13,12 +13,22 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.responses import JSONResponse
 
+# --- 1. Import du nouveau handler ---
+from src.shared.log_handler import InMemoryLogHandler
+
 from src.shared.service_discovery import get_gra_base_url, register_self_with_gra
 from .executor import DevelopmentAgentExecutor
 from .logic import AGENT_SKILL_CODING_PYTHON
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+
+# --- 2. Initialisation et configuration du logging ---
+in_memory_log_handler = InMemoryLogHandler(maxlen=200)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+in_memory_log_handler.setFormatter(formatter)
+logging.getLogger().addHandler(in_memory_log_handler)
+logging.getLogger().setLevel(logging.INFO)
 
 AGENT_NAME = "DevelopmentAgentServer"
 
@@ -52,6 +62,11 @@ def get_development_agent_card() -> AgentCard:
 agent_executor = DevelopmentAgentExecutor()
 task_store = InMemoryTaskStore()
 request_handler = DefaultRequestHandler(agent_executor=agent_executor, task_store=task_store)
+
+# --- 3. Création de l'endpoint /logs ---
+async def logs_endpoint(request):
+    """Retourne les dernières lignes de log de l'agent."""
+    return JSONResponse(content=in_memory_log_handler.get_logs())
 
 @contextlib.asynccontextmanager
 async def lifespan(app_param: Starlette):
@@ -98,8 +113,13 @@ def create_app_instance() -> Starlette:
         Route("/status", endpoint=status_endpoint, methods=["GET"])
     )
 
+    # --- 4. Ajout de la nouvelle route ---
+    app.router.routes.append(
+        Route("/logs", endpoint=logs_endpoint, methods=["GET"])
+    )
+
     app.router.lifespan_context = lifespan
-    
+
     return app
 
 app = create_app_instance()

--- a/src/agents/reformulator/server.py
+++ b/src/agents/reformulator/server.py
@@ -12,6 +12,9 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.responses import JSONResponse
 
+# --- 1. Import du nouveau handler ---
+from src.shared.log_handler import InMemoryLogHandler
+
 from src.shared.service_discovery import register_self_with_gra
 from .executor import ReformulatorAgentExecutor
 
@@ -19,6 +22,13 @@ AGENT_NAME = "ReformulatorAgentServer"
 logger = logging.getLogger(__name__)
 if not logger.hasHandlers():
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+# --- 2. Initialisation et configuration du logging ---
+in_memory_log_handler = InMemoryLogHandler(maxlen=200)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+in_memory_log_handler.setFormatter(formatter)
+logging.getLogger().addHandler(in_memory_log_handler)
+logging.getLogger().setLevel(logging.INFO)
 
 def get_reformulator_agent_card() -> AgentCard:
     """
@@ -92,13 +102,23 @@ def create_app_instance() -> Starlette:
     )
     app.router.routes.append(
         Route("/status", endpoint=status_endpoint, methods=["GET"])
-    )    
+    )
+
+    # --- 4. Ajout de la nouvelle route ---
+    app.router.routes.append(
+        Route("/logs", endpoint=logs_endpoint, methods=["GET"])
+    )
     app.router.lifespan_context = lifespan
-    
+
     return app
 agent_executor = ReformulatorAgentExecutor()
 task_store = InMemoryTaskStore()
 request_handler = DefaultRequestHandler(agent_executor=agent_executor, task_store=task_store)
+
+# --- 3. Création de l'endpoint /logs ---
+async def logs_endpoint(request):
+    """Retourne les dernières lignes de log de l'agent."""
+    return JSONResponse(content=in_memory_log_handler.get_logs())
 app = create_app_instance()
 
 if __name__ == "__main__":

--- a/src/agents/research_agent/server.py
+++ b/src/agents/research_agent/server.py
@@ -13,12 +13,22 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.responses import JSONResponse
 
+# --- 1. Import du nouveau handler ---
+from src.shared.log_handler import InMemoryLogHandler
+
 from src.shared.service_discovery import get_gra_base_url, register_self_with_gra
 from .executor import ResearchAgentExecutor
 from .logic import AGENT_SKILL_GENERAL_ANALYSIS, AGENT_SKILL_WEB_RESEARCH, AGENT_SKILL_DOCUMENT_SYNTHESIS
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+
+# --- 2. Initialisation et configuration du logging ---
+in_memory_log_handler = InMemoryLogHandler(maxlen=200)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+in_memory_log_handler.setFormatter(formatter)
+logging.getLogger().addHandler(in_memory_log_handler)
+logging.getLogger().setLevel(logging.INFO)
 
 AGENT_NAME = "ResearchAgentServer"
 
@@ -64,6 +74,11 @@ agent_executor = ResearchAgentExecutor()
 task_store = InMemoryTaskStore()
 request_handler = DefaultRequestHandler(agent_executor=agent_executor, task_store=task_store)
 
+# --- 3. Création de l'endpoint /logs ---
+async def logs_endpoint(request):
+    """Retourne les dernières lignes de log de l'agent."""
+    return JSONResponse(content=in_memory_log_handler.get_logs())
+
 @contextlib.asynccontextmanager
 async def lifespan(app_param: Starlette):
     logger.info(f"[{AGENT_NAME}] Démarrage du cycle de vie (lifespan)...")
@@ -105,9 +120,14 @@ def create_app_instance() -> Starlette:
     )
     app.router.routes.append(
         Route("/status", endpoint=status_endpoint, methods=["GET"])
-    )       
+    )
+
+    # --- 4. Ajout de la nouvelle route ---
+    app.router.routes.append(
+        Route("/logs", endpoint=logs_endpoint, methods=["GET"])
+    )
     app.router.lifespan_context = lifespan
-    
+
     return app
 
 app = create_app_instance()

--- a/src/agents/user_interaction_agent/server.py
+++ b/src/agents/user_interaction_agent/server.py
@@ -13,12 +13,22 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.responses import JSONResponse
 
+# --- 1. Import du nouveau handler ---
+from src.shared.log_handler import InMemoryLogHandler
+
 from src.shared.service_discovery import get_gra_base_url, register_self_with_gra
 from .executor import UserInteractionAgentExecutor
 from .logic import ACTION_CLARIFY_OBJECTIVE
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 logger = logging.getLogger(__name__)
+
+# --- 2. Initialisation et configuration du logging ---
+in_memory_log_handler = InMemoryLogHandler(maxlen=200)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+in_memory_log_handler.setFormatter(formatter)
+logging.getLogger().addHandler(in_memory_log_handler)
+logging.getLogger().setLevel(logging.INFO)
 
 AGENT_NAME = "UserInteractionAgentServer"
 
@@ -58,6 +68,11 @@ def get_user_interaction_agent_card() -> AgentCard:
 agent_executor = UserInteractionAgentExecutor()
 task_store = InMemoryTaskStore()
 request_handler = DefaultRequestHandler(agent_executor=agent_executor, task_store=task_store)
+
+# --- 3. Création de l'endpoint /logs ---
+async def logs_endpoint(request):
+    """Retourne les dernières lignes de log de l'agent."""
+    return JSONResponse(content=in_memory_log_handler.get_logs())
 
 @contextlib.asynccontextmanager
 async def lifespan(app_param: Starlette):
@@ -100,9 +115,14 @@ def create_app_instance() -> Starlette:
     )
     app.router.routes.append(
         Route("/status", endpoint=status_endpoint, methods=["GET"])
-    )       
+    )
+
+    # --- 4. Ajout de la nouvelle route ---
+    app.router.routes.append(
+        Route("/logs", endpoint=logs_endpoint, methods=["GET"])
+    )
     app.router.lifespan_context = lifespan
-    
+
     return app
 
 app = create_app_instance()

--- a/src/agents/validator/server.py
+++ b/src/agents/validator/server.py
@@ -16,12 +16,22 @@ from starlette.applications import Starlette
 from starlette.routing import Route
 from starlette.responses import JSONResponse
 
+# --- 1. Import du nouveau handler ---
+from src.shared.log_handler import InMemoryLogHandler
+
 from src.shared.service_discovery import register_self_with_gra
 from .executor import ValidatorAgentExecutor
 
 logger = logging.getLogger(__name__)
 if not logger.hasHandlers():
     logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+# --- 2. Initialisation et configuration du logging ---
+in_memory_log_handler = InMemoryLogHandler(maxlen=200)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+in_memory_log_handler.setFormatter(formatter)
+logging.getLogger().addHandler(in_memory_log_handler)
+logging.getLogger().setLevel(logging.INFO)
 
 AGENT_NAME = "ValidatorAgentServer"
 
@@ -58,6 +68,11 @@ def get_validator_agent_card() -> AgentCard:
 agent_executor = ValidatorAgentExecutor()
 task_store = InMemoryTaskStore()
 request_handler = DefaultRequestHandler(agent_executor=agent_executor, task_store=task_store)
+
+# --- 3. Création de l'endpoint /logs ---
+async def logs_endpoint(request):
+    """Retourne les dernières lignes de log de l'agent."""
+    return JSONResponse(content=in_memory_log_handler.get_logs())
 
 @contextlib.asynccontextmanager
 async def lifespan(app_param: Starlette):
@@ -100,9 +115,14 @@ def create_app_instance() -> Starlette:
     )
     app.router.routes.append(
         Route("/status", endpoint=status_endpoint, methods=["GET"])
-    )    
+    )
+
+    # --- 4. Ajout de la nouvelle route ---
+    app.router.routes.append(
+        Route("/logs", endpoint=logs_endpoint, methods=["GET"])
+    )
     app.router.lifespan_context = lifespan
-    
+
     return app
 
 app = create_app_instance()


### PR DESCRIPTION
## Summary
- integrate `InMemoryLogHandler` across all agents
- expose `/logs` endpoint in each agent server

## Testing
- `pip install -q -r requirements.txt` *(fails: ResolutionImpossible)*
- `pytest -q` *(fails: ModuleNotFoundError: kubernetes, httpx, vertexai)*

------
https://chatgpt.com/codex/tasks/task_e_6856c37ab344832d8eb1b93511cae297