### PR TITLE
Add GRA log viewing in React dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ OrchestrAI turns any vague user goal into a detailed action plan and concrete de
 - **Full audit trail**: Every decision, correction and outcome is persisted in Firestore for transparency.
 - **Isolated dev environments**: Generated code runs in Kubernetes pods managed by the `EnvironmentManager` for safety (see `docs/environment_manager.md`). Environment metadata lives in Firestore and, when no dedicated pod can be created, the manager reuses a shared `exec_default` environment (see `scripts/create_fallback_environment.py`).
 - **Real-time agent status**: The GRA exposes `/gra_status` and `/ws/status` endpoints so the dashboard can display each agent's operational state (Idle, Busy, Working, etc.).
-- **Agent logs**: Each agent exposes a `/logs` route and the GRA proxies it via `/v1/agents/<name>/logs` so the dashboard can fetch runtime logs securely.
+- **Agent logs**: Each agent exposes a `/logs` route and the GRA proxies it via `/v1/agents/<name>/logs` so the dashboard can fetch runtime logs securely. The GRA server itself exposes `/v1/gra/logs`.
 
 ---
 

--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -265,6 +265,15 @@ function AgentStatusBar({ agents, graHealth, stats, onViewLogs, onRestart }) {
           {graHealth === 'online' ? '✅ Online' : '⚠️ Offline'}
         </div>
       </div>
+      <div className="agent-actions">
+        <button
+          className="icon-btn"
+          title="View logs"
+          onClick={() => onViewLogs && onViewLogs('gra')}
+        >
+          <i className="fa-solid fa-file-lines"></i>
+        </button>
+      </div>
     </div>
   );
   const supervisorsNames = ['GlobalSupervisorLogic', 'ExecutionSupervisorLogic'];
@@ -1067,21 +1076,26 @@ function App() {
       .catch(err => console.error('Error retrying failed tasks', err));
   }
 
-  async function openLogs(agent) {
-    if (!agent?.name) return;
+  async function openLogs(target) {
+    const name = typeof target === 'string' ? target : target?.name;
+    if (!name) return;
+    const url =
+      name === 'gra'
+        ? `${BACKEND_API_URL}/v1/gra/logs`
+        : `${BACKEND_API_URL}/v1/agents/${encodeURIComponent(name)}/logs`;
     try {
-      const res = await fetch(
-        `${BACKEND_API_URL}/v1/agents/${encodeURIComponent(agent.name)}/logs`
-      );
+      const res = await fetch(url);
       if (!res.ok) {
         const errData = await res.json().catch(() => ({}));
         throw new Error(errData.detail || `HTTP ${res.status}`);
       }
       const data = await res.json();
       const logs = Array.isArray(data) ? data : [JSON.stringify(data)];
-      setLogModal({ agentName: agent.name, logs });
+      const displayName = name === 'gra' ? 'GRA Server' : name;
+      setLogModal({ agentName: displayName, logs });
     } catch (err) {
-      setLogModal({ agentName: agent.name, logs: [`Error: ${err.message}`] });
+      const displayName = name === 'gra' ? 'GRA Server' : name;
+      setLogModal({ agentName: displayName, logs: [`Error: ${err.message}`] });
     }
   }
 

--- a/src/services/gra/server.py
+++ b/src/services/gra/server.py
@@ -28,8 +28,15 @@ from google.oauth2 import id_token
 from google.auth.transport.requests import Request as GoogleAuthRequest
 
 from starlette.applications import Starlette
+from src.shared.log_handler import InMemoryLogHandler
 
 logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+in_memory_log_handler = InMemoryLogHandler(maxlen=200)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+in_memory_log_handler.setFormatter(formatter)
+logging.getLogger().addHandler(in_memory_log_handler)
+logging.getLogger().setLevel(logging.INFO)
 def json_serializer(obj):
     """
     Traducteur JSON robuste pour les objets non sérialisables par défaut.
@@ -1106,6 +1113,12 @@ async def get_agent_logs(agent_name: str):
     except Exception as e:
         logger.error(f"Error retrieving logs for agent {agent_name}: {e}", exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to fetch agent logs")
+
+
+@app.get("/v1/gra/logs")
+async def get_gra_logs():
+    """Return recent GRA server log lines."""
+    return in_memory_log_handler.get_logs()
 
 
 @app.post("/v1/agents/{agent_name}/restart")


### PR DESCRIPTION
## Summary
- expose `/v1/gra/logs` from the GRA server
- keep recent GRA logs in memory
- allow the React dashboard to fetch those logs
- display a log button on the GRA card
- document the new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'kubernetes')*

------
https://chatgpt.com/codex/tasks/task_e_685824f7335c832d8308efd1a3ff320c