### PR TITLE
Group plan info in single card

### DIFF
--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -372,30 +372,32 @@ function PlanInfo({ plan, flowRunning, hasFailures, team1Counts, team2Counts, on
       <details className="plan-meta" open>
         <summary>Plan details</summary>
         <div className="plan-cards">
-          <div className="plan-card">
-            <div className="card-header">Plan ID</div>
-            <div className="card-content">{plan.global_plan_id}</div>
-          </div>
-          {plan.environment_id && (
-            <div className="plan-card">
-              <div className="card-header">Environment ID</div>
-              <div className="card-content">
-                {plan.environment_id}
-                {onDeleteEnvironment && (
-                  <button
-                    style={{ marginLeft: '0.5rem' }}
-                    onClick={() => onDeleteEnvironment(plan.environment_id)}
-                    title="Delete this environment"
-                  >
-                    🗑
-                  </button>
-                )}
-              </div>
+          <div className="plan-card grouped-info">
+            <div className="info-row">
+              <div className="card-header">Plan ID</div>
+              <div className="card-content">{plan.global_plan_id}</div>
             </div>
-          )}
-          <div className="plan-card">
-            <div className="card-header">Raw Objective</div>
-            <div className="card-content">{plan.raw_objective}</div>
+            {plan.environment_id && (
+              <div className="info-row">
+                <div className="card-header">Environment ID</div>
+                <div className="card-content">
+                  {plan.environment_id}
+                  {onDeleteEnvironment && (
+                    <button
+                      style={{ marginLeft: '0.5rem' }}
+                      onClick={() => onDeleteEnvironment(plan.environment_id)}
+                      title="Delete this environment"
+                    >
+                      🗑
+                    </button>
+                  )}
+                </div>
+              </div>
+            )}
+            <div className="info-row">
+              <div className="card-header">Raw Objective</div>
+              <div className="card-content">{plan.raw_objective}</div>
+            </div>
           </div>
           {plan.clarified_objective && (
             <div className="plan-card">

--- a/react_frontend/style.css
+++ b/react_frontend/style.css
@@ -280,6 +280,17 @@ input {
   gap: 0.5rem;
 }
 
+.plan-card.grouped-info {
+  flex-direction: column;
+}
+
+.plan-card.grouped-info .info-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
 .card-header {
   font-weight: bold;
   min-width: 140px;


### PR DESCRIPTION
## Summary
- display Plan ID, Environment ID and Raw Objective together in one card
- add styles for new grouped layout

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685834de96f4832d8988949a86c02ef0