### PR TITLE
Update env manager usage

### DIFF
--- a/docs/environment_manager.md
+++ b/docs/environment_manager.md
@@ -4,4 +4,6 @@ Internal service that creates isolated Kubernetes environments where generated c
 
 The manager stores environment metadata in the `kubernetes_environments` Firestore collection. When no dedicated environment is found for a plan, a fallback environment identified by `exec_default` can be used. A helper script `scripts/create_fallback_environment.py` is provided to create this fallback pod.
 
+Generated code is executed inside a working directory mounted at `/app` in each pod.
+
 The GRA exposes `/api/environments/{env_id}` (DELETE) to remove a pod and its persistent volume claim. The React dashboard uses this endpoint to let you clean up environments.

--- a/react_frontend/app.jsx
+++ b/react_frontend/app.jsx
@@ -17,6 +17,9 @@ const TYPE_COLORS = {
   decomposition: '#9c27b0'
 };
 
+// Root directory of each isolated environment inside the pod
+const ENV_WORKDIR = '/app';
+
 function parseMaybeJson(data) {
   if (!data) return data;
   if (typeof data === 'string') {
@@ -693,7 +696,7 @@ function FileBrowser({ environmentId, planId }) {
     <div className="file-browser">
       <h3>File Explorer (ID: {environmentId})</h3>
       <div className="path-bar">
-        <span>Path: /app/{currentPath}</span>
+        <span>Path: {ENV_WORKDIR}/{currentPath}</span>
         <div className="file-actions">
           <input
             type="file"

--- a/src/services/gra/server.py
+++ b/src/services/gra/server.py
@@ -18,7 +18,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.middleware.cors import CORSMiddleware
 import json
 from src.shared.execution_task_graph_management import ExecutionTaskGraph
-from src.services.environment_manager.environment_manager import EnvironmentManager
+from src.services.environment_manager import EnvironmentManager
 from kubernetes import client
 from src.orchestrators.global_supervisor_logic import GlobalSupervisorLogic, GlobalPlanState 
 from starlette.websockets import WebSocket, WebSocketDisconnect
@@ -897,7 +897,7 @@ async def get_agent_stats():
 
 @app.get("/api/environments/{environment_id}/files")
 async def list_files(environment_id: str, path: Optional[str] = "."):
-    """Liste les fichiers dans un environnement. Le chemin est relatif à /workspace."""
+    """Liste les fichiers dans un environnement. Le chemin est relatif à /app."""
     if not environment_manager:
         raise HTTPException(status_code=503, detail="EnvironmentManager is not available.")
     try:


### PR DESCRIPTION
## Summary
- switch GRA server to package level EnvironmentManager import
- update file browser root path constant to `/app`
- document new `/app` working directory
- adjust path comment in GRA endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685b8fc19f60832dbd49b9592f005340