### PR TITLE
Update docs for React frontend migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ A strategic orchestration engine for multi-agent systems. OrchestrAI turns vague
 - **Agent logs (syslog)**: Each agent exposes a `/logs` route and the GRA proxies it via `/v1/agents/<name>/logs` so the dashboard can fetch runtime logs securely. The GRA server itself exposes `/v1/gra/logs`.
 - **Agent restart**: The dashboard provides a restart button calling `/v1/agents/<name>/restart` which relays to each agent's own `/restart` endpoint.
 - **Pod file browser**: Files generated inside an isolated environment can be listed, downloaded and uploaded via `/api/environments/<id>/files` and related routes.
+- **Execution graph editor**: A `TaskGraphEditor` component lets you create and modify execution plans directly from the React dashboard through CRUD endpoints.
 
 ---
 
@@ -385,7 +386,13 @@ The `deployment.sh` script can generate a `docker-compose.yml` file to launch al
     ```
     This builds the images and starts the nine containers.
 
-3. **Access the Front End:** the React front end is served by the `user_interaction_agent` service and is available on the port defined in `docker-compose.yml`.
+3. **Access the Front End:**
+   ```bash
+   cd react_frontend_modern
+   npm install
+   npm run dev
+   ```
+   The Vite dev server exposes the dashboard on <http://localhost:5173>. When deployed, the compiled files under `dist/` are served via Firebase Hosting.
 
 ## Cloud / Firebase Deployment
 
@@ -454,7 +461,7 @@ orchestrai-hackathon-ADK/
 │   ├── app_frontend.py
 │   └── run_orchestrator.py
 ├── docs/                  # Documentation and diagrams
-├── react_frontend/        # React dashboard
+├── react_frontend_modern/        # React dashboard (Vite + TypeScript)
 ├── scripts/               # Helper and deployment scripts
 ├── tests/                 # Unit and integration tests
 ├── deployment.sh          # Cloud Run deployment
@@ -484,6 +491,8 @@ Several helper scripts are provided for deployment and maintenance tasks.
 - `scripts/grant_agent_permissions.sh` – allow inter-service Cloud Run invocations.
 - `scripts/grant_gke_permissions_to_cloudrun_sa.sh` – give the Cloud Run service account access to GKE.
 - `scripts/grant_gclou_kubernet.sh` – example script to set up GCP and Kubernetes roles.
+- `scripts/gc_cleanup.sh` – Cloud Run job template to clean old images from GCR.
+- `setup_new_frontend.sh` – helper to bootstrap the Vite/TypeScript frontend from the legacy project.
 - `tests/run_test_development_agent.sh` – run an end‑to‑end test against the development agent pod.
 - `tests/run_test_environment_manager.sh` – test the environment manager API.
 
@@ -492,7 +501,7 @@ Several helper scripts are provided for deployment and maintenance tasks.
 - `scripts/cleanup_firestore_plans.py` – remove unfinished plans from Firestore.
 - `src/run_orchestrator.py` – trigger a planning sequence from the command line.
 - `src/tests/k8s_iam_test_server.py` – FastAPI server to test GKE IAM authentication.
-- `react_frontend/secure_server.py` – run the React front end with HTTPS.
+- `react_frontend_modern/` – run the React front end locally with `npm run dev` or build with `npm run build`.
 - `init_projet.py.initial` – example project scaffolding utility.
 
 ## Future Enhancements

--- a/react_frontend_modern/README.md
+++ b/react_frontend_modern/README.md
@@ -1,69 +1,33 @@
-# React + TypeScript + Vite
+# React Frontend (Vite + TypeScript)
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This folder contains the modern React dashboard used by OrchestrAI.
+It replaces the legacy `react_frontend` project and is powered by
+[Vite](https://vitejs.dev/) and TypeScript.
 
-Currently, two official plugins are available:
+## Development
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+cd react_frontend_modern
+npm install
+npm run dev
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The dev server runs on <http://localhost:5173> and expects a
+`public/config.js` file setting `window.CONFIG.BACKEND_API_URL` to the
+GRA endpoint.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Build & Deploy
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm run build
 ```
+
+The generated files under `dist/` are deployed to Firebase Hosting by
+running `./deployment.sh deploy_frontend` from the repository root.
+
+## TaskGraphEditor
+
+The dashboard embeds a `TaskGraphEditor` component based on React Flow.
+It uses the GRA's CRUD API to create, update and delete nodes and
+dependencies of an execution plan.
+

--- a/src/services/gra/README.md
+++ b/src/services/gra/README.md
@@ -9,3 +9,13 @@
 - Implements the Resource and Agent Manager (GRA).
 - Allows agent registration and discovery through REST endpoints.
 - Serves as a single entry point for the front-end and supervisors.
+
+Recent additions expose CRUD routes to edit execution graphs:
+
+- `POST   /v1/execution_task_graphs/{plan_id}/nodes`
+- `PUT    /v1/execution_task_graphs/{plan_id}/nodes/{node_id}`
+- `DELETE /v1/execution_task_graphs/{plan_id}/nodes/{node_id}`
+- `POST   /v1/execution_task_graphs/{plan_id}/dependencies`
+- `DELETE /v1/execution_task_graphs/{plan_id}/dependencies/{source}/{target}`
+
+These power the `TaskGraphEditor` component in the React front end.


### PR DESCRIPTION
## Summary
- document the new Vite/TypeScript dashboard
- update references to `react_frontend_modern`
- list new scripts and CRUD graph endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_686a7630abf0832da83b276324686b96