### PR TITLE
Enhance artifact history display

### DIFF
--- a/react_frontend_modern/src/App.tsx
+++ b/react_frontend_modern/src/App.tsx
@@ -570,12 +570,27 @@ function FinalArtifactsHistory({ nodes }: { nodes: any }) {
       (!n.sub_task_ids || n.sub_task_ids.length === 0) &&
       n.output_artifact_ref
     );
+    const depthCache: { [key: string]: number } = {};
+    const computeDepth = (id: string): number => {
+      if (depthCache[id] !== undefined) return depthCache[id];
+      const node = (nodes as any)[id];
+      if (!node || !node.parent_id) {
+        depthCache[id] = 0;
+        return 0;
+      }
+      depthCache[id] = computeDepth(node.parent_id) + 1;
+      return depthCache[id];
+    };
+
     Promise.all(
       finals.map((n: any) =>
         fetch(`${BACKEND_API_URL}/artifacts/${n.output_artifact_ref}`)
           .then(r => r.json())
           .then(d => ({
-            task: n.objective || n.id,
+            id: n.id,
+            title: n.objective,
+            parent: n.parent_id,
+            depth: computeDepth(n.id),
             content: parseMaybeJson(d.content),
             updated: n.updated_at || ''
           }))
@@ -588,7 +603,9 @@ function FinalArtifactsHistory({ nodes }: { nodes: any }) {
           if (!a || !b) return 0;
           return new Date(a.updated).getTime() - new Date(b.updated).getTime();
         })
-        .map(it => it ? { ...it, type: detectArtifactType(it.content) } : null)
+        .map(it =>
+          it ? { ...it, type: detectArtifactType(it.content) } : null
+        )
         .filter(Boolean);
       setItems(arr);
     });
@@ -612,25 +629,32 @@ function FinalArtifactsHistory({ nodes }: { nodes: any }) {
   };
 
   return (
-    <div className="messages-history">
-      <h4>Final artifacts history</h4>
+    <details className="artifacts-container" open>
+      <summary>📜 Final artifacts history</summary>
       {Object.entries(grouped).map(([type, list]) => (
         list.length ? (
           <div key={type} className="artifact-section">
             <h5>{typeLabels[type]}</h5>
             {list.map((it, idx) => (
-              <div key={idx} className="message-item">
-                <div><strong>Task:</strong> {it.task}</div>
-                {it.updated && (
-                  <div className="msg-date">{new Date(it.updated).toLocaleString()}</div>
-                )}
+              <div
+                key={idx}
+                className="message-item"
+                style={{ marginLeft: `${it.depth * 1.5}rem` }}
+              >
+                <div className="artifact-header">
+                  <span><strong>ID:</strong> {it.id}</span>
+                  {it.updated && (
+                    <span className="msg-date">{new Date(it.updated).toLocaleString()}</span>
+                  )}
+                </div>
+                {it.title && <div className="artifact-title">{it.title}</div>}
                 <FormattedContent data={it.content} open />
               </div>
             ))}
           </div>
         ) : null
       ))}
-    </div>
+    </details>
   );
 }
 

--- a/react_frontend_modern/src/styles/main.css
+++ b/react_frontend_modern/src/styles/main.css
@@ -415,12 +415,33 @@ input {
 .messages-history {
   margin-top: 1rem;
 }
+.artifacts-container {
+  border: 1px solid var(--border);
+  padding: 0.5rem;
+  margin-bottom: 1rem;
+  background: var(--card-bg);
+}
+.artifacts-container summary {
+  cursor: pointer;
+  margin-bottom: 0.5rem;
+  font-weight: bold;
+}
 .artifact-section {
   margin-bottom: 1rem;
 }
 .artifact-section h5 {
   margin: 0 0 0.5rem 0;
   font-size: 1rem;
+}
+.artifact-header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 0.25rem;
+  font-size: 0.85rem;
+}
+.artifact-title {
+  font-weight: bold;
+  margin-bottom: 0.25rem;
 }
 .message-item {
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- improve FinalArtifactsHistory component hierarchy and header fields
- add collapsible container and indentation for artifacts
- style updated artifact container

## Testing
- `pytest -q` *(fails: ImportError cannot import name 'ExecutionTaskState' from 'src.shared.execution_task_graph_management')*

------
https://chatgpt.com/codex/tasks/task_e_686a9db73ab8832db59505ec86df8ee0