### PR TITLE
Fix capability check tool list

### DIFF
--- a/src/shared/base_agent_logic.py
+++ b/src/shared/base_agent_logic.py
@@ -161,7 +161,7 @@ class BaseAgentLogic(ABC):
     
     async def tool_capability_check(self, input: dict) -> dict:
         deliverable = input.get("deliverable_description", "")
-        tool_list = list(self.registered_tools.keys())
+        tool_list = list(self.tool_registry.tools.keys())
 
         return {
             "can_handle": self.can_deliver(deliverable),


### PR DESCRIPTION
## Summary
- use tool registry's tool list in `tool_capability_check`

## Testing
- `python -m pytest tests/unit/test_decomposition_logic.py::test_decomposition_logic_valid_plan_mocked_llm -q`
- `python -m pytest src/tests/test_dev_agent_executor_tool_call.py::test_capability_check_tool -q` *(fails: 'can_handle' missing due to LLM configuration)*
- `python -m pytest src/tests/test_palier_6_tool_invoke.py::test_trace_and_artifact_tool_invoke -q` *(fails: Firestore not configured)*

------
https://chatgpt.com/codex/tasks/task_e_687bae24c424832d95b712d1febc0da1