### PR TITLE
Fix duplicate imports

### DIFF
--- a/src/shared/base_agent_logic.py
+++ b/src/shared/base_agent_logic.py
@@ -13,8 +13,6 @@ from src.shared.firebase_init import get_firestore_client
 
 from src.shared.prompt_utils import build_dynamic_system_prompt
 from src.shared.tool_registry import ToolRegistry
-import uuid
-from datetime import datetime
 
 import src.shared.interaction_logger as interaction_logger
 

--- a/src/shared/tool_registry.py
+++ b/src/shared/tool_registry.py
@@ -5,9 +5,10 @@ from typing import Callable, Optional
 from src.tools import development_tools  # Exporte les outils Python spécifiques
 from src.tools import generic_tools  # Exporte des outils plus transversaux
 from src.shared.execution_task_graph_management import ExecutionTaskGraph, ExecutionTaskNode,ExecutionTaskType
- 
+
 
 import uuid
+from datetime import datetime
 logger = logging.getLogger(__name__)
 
 import logging
@@ -86,8 +87,6 @@ class ToolRegistry:
 
     async def handle_llm_response(self, llm_response: str | dict, context_id: Optional[str] = None) -> Optional[dict]:
         import json
-        import uuid
-        from datetime import datetime
         from src.shared.interaction_logger import save_interaction_artifact
         from src.shared.execution_task_graph_management import ExecutionTaskNode, ExecutionTaskGraph, ExecutionTaskType
 


### PR DESCRIPTION
## Summary
- consolidate repeated imports at top of `BaseAgentLogic`
- move datetime/uuid imports to top of `tool_registry`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: test_capability_check_tool, test_trace_and_artifact_tool_invoke, test_decomposition_logic_valid_plan_mocked_llm, test_retry_failed_tasks_resets_and_calls_continue)*

------
https://chatgpt.com/codex/tasks/task_e_687bb1fa8d90832db326c22c7e856686