### PR TITLE
Fix default LLM model setting

### DIFF
--- a/src/shared/llm_client.py
+++ b/src/shared/llm_client.py
@@ -9,7 +9,6 @@ logger = logging.getLogger(__name__)
 GCP_PROJECT_ID = os.environ.get("GCP_PROJECT_ID")
 GCP_REGION = os.environ.get("GCP_REGION")
 
-LLM_MODEL = os.environ.get("LLM_MODEL", "gemini-1.5-flash-001")
 LLM_MODEL = os.environ.get("LLM_MODEL", "gemini-2.0-flash-001")
 
 try:


### PR DESCRIPTION
## Summary
- clean up llm_client to define `LLM_MODEL` only once

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_687bb6609af0832dbb9a73e14ad96eef