### PR TITLE
Update docs for tool-based agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,34 +1,34 @@
-# AGENTS.md - point d'entrée pour moteurs multi-agents
+# AGENTS.md - Multi-agent quick start
 
-Ce dépôt contient un système multi-agents complet basé sur l'**Agent Development Kit (ADK)**. Il permet de clarifier un objectif utilisateur, de générer un plan détaillé puis d'exécuter ce plan via plusieurs agents spécialisés.
+This repository implements a complete multi-agent framework built on top of the **Google Agent Development Kit (ADK)**. Agents collaborate to clarify goals, generate a plan and execute tasks using skill-specific tools.
 
-## Vue d'ensemble
+## Overview
 
-1. **Clarification** : `UserInteractionAgent` interagit avec l'utilisateur pour affiner l'objectif initial.
-2. **Planification (TEAM 1)** : `Reformulator`, `Evaluator`, `Validator` génèrent et valident un plan détaillé orchestré par `PlanningSupervisorLogic`.
-3. **Exécution (TEAM 2)** : `DecompositionAgent` découpe le plan validé. `Development`, `Research` et `Testing` réalisent concrètement les tâches orchestrées par `ExecutionSupervisorLogic`.
-4. **Supervision Globale** : `GlobalSupervisorLogic` pilote les phases précédentes et gère les états dans Firestore.
-5. **Gestionnaire de Ressources (GRA)** : service FastAPI centralisant l'enregistrement et la découverte des agents.
-6. **Interface** : `src/app_frontend.py` expose un tableau de bord Streamlit pour soumettre et suivre les plans.
+1. **Clarification**: `UserInteractionAgent` interacts with the user to refine the objective.
+2. **Planning (TEAM 1)**: `Reformulator`, `Evaluator` and `Validator` craft a detailed plan orchestrated by `PlanningSupervisorLogic`.
+3. **Execution (TEAM 2)**: `DecompositionAgent` splits the validated plan. `Development`, `Research` and `Testing` agents perform concrete tasks under `ExecutionSupervisorLogic`.
+4. **Tool-based agents**: All logics inherit from `BaseAgentLogic` which loads tools from a `ToolRegistry`. Tools live in `src/tools/` and include `generate_code_and_write_file`, `execute_command`, `workforce_information` and `capability_check`.
+5. **Global supervision**: `GlobalSupervisorLogic` coordinates the phases and stores state in Firestore.
+6. **GRA service**: FastAPI registry exposing agent discovery and status endpoints.
+7. **Dashboard**: `src/app_frontend.py` offers a Streamlit UI to submit goals and follow progress.
 
-Les agents sont implémentés sous `src/agents/` (un répertoire par agent). Chaque agent fournit :
-- `server.py` : serveur A2A (ASGI) exposant son API.
-- `logic.py` : logique métier s'appuyant sur un LLM (Gemini).
-- `executor.py` : wrapper pour exécuter la logique.
+Agents live under `src/agents/<agent>` and provide:
+- `server.py` – A2A server exposing the API.
+- `logic.py` – Business logic based on `BaseAgentLogic`.
+- `executor.py` – Helper to run the logic.
 
-Les orchestrateurs se trouvent sous `src/orchestrators/` et utilisent `src/shared/` pour la gestion des graphes de tâches, la connexion Firestore et l'accès LLM.
+Orchestrators are located in `src/orchestrators/` and rely on `src/shared/` for task graph management, Firestore access and LLM utilities.
 
-## Démarrage rapide
+## Quick Start
 
-1. Installer les dépendances : `pip install -r requirements.txt`.
-2. Lancer le GRA : `python -m src.services.gra.server`.
-3. Démarrer chaque agent (`python -m src.agents.<agent>.server`).
-4. Lancer l'interface : `streamlit run src/app_frontend.py`.
+1. Install dependencies: `pip install -r requirements.txt`.
+2. Start the GRA: `python -m src.services.gra.server`.
+3. Run each agent: `python -m src.agents.<agent>.server`.
+4. Launch the dashboard: `streamlit run src/app_frontend.py`.
 
-Les plans et graphes sont stockés dans Firestore (`global_plans`, `task_graphs`, `execution_task_graphs`, `agents`).
+Firestore collections `global_plans`, `task_graphs`, `execution_task_graphs` and `agents` store the orchestration state.
 
-## Références utiles
-- `README.md` : description détaillée de l'architecture et des phases du système.
-- `src/run_orchestrator.py` : exemple de lancement de plan par script.
-- `tests/` : exemples de tests automatisés.
-
+## References
+- `README.md` for a full architecture overview.
+- `src/run_orchestrator.py` for running a plan from the command line.
+- `tests/` for automated tests.

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ The project implements a multi-level orchestration pattern with persistent state
 * **Service discovery via the GRA** stores agent metadata in Firestore.
 * **Iterative planning** allows plan revisions until validation.
 * **LLM-powered logic** relies on Gemini models through `llm_client.py`.
+* **Tool-based agent logic** via `BaseAgentLogic` and a `ToolRegistry` that loads
+  skill-specific tools such as `workforce_information` and `capability_check`.
 
 ## ⚙️ Installation & Prerequisites
 
@@ -428,7 +430,9 @@ The script automatically injects the correct environment variables (`GCP_PROJECT
 ## How to Add Your Agent
 
 1. **Create a folder** under `src/agents/<your_agent>`.
-2. Add `logic.py`, `executor.py` and `server.py` implementing the agent logic.
+2. Add `logic.py`, `executor.py` and `server.py` implementing the agent logic. Your
+   `logic.py` should subclass `BaseAgentLogic` and declare the tools available via
+   the `ToolRegistry`.
 3. Make the server register itself to the GRA using the `/v1/agents/register` endpoint.
 4. Add a Dockerfile and update `deployment.sh` to build and deploy your new image.
 5. Deploy with `./deployment.sh deploy-one <your_agent>` once the image is built.


### PR DESCRIPTION
## Summary
- refresh AGENTS.md with current architecture and tool registry
- mention the new ToolRegistry system in README
- document how to subclass `BaseAgentLogic` when creating a new agent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'vertexai')*

------
https://chatgpt.com/codex/tasks/task_e_687bed5135ac832da62e91caacdfef8d