### PR TITLE
Document integration tests

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -4,8 +4,10 @@
 - Ensemble des tests automatisés du projet.
 - Inclut des tests d'intégration et les unités dans `unit/`.
 - Peut être exécuté via `pytest`.
+- Consultez `TESTS_GUIDE.md` pour une description détaillée de chaque test.
 
 **English:**
 - Collection of automated tests for the project.
 - Includes integration tests and the unit tests under `unit/`.
 - Run them with `pytest`.
+- See `TESTS_GUIDE.md` for a detailed description of each test.

--- a/tests/TESTS_GUIDE.md
+++ b/tests/TESTS_GUIDE.md
@@ -1,0 +1,75 @@
+# TESTS_GUIDE
+
+This document lists the available test scripts and explains how to run them.
+It complements the short `README.md` and helps understand the prerequisites
+for each test.
+
+## Integration tests
+
+- **check_health.py**
+  - Checks that every agent registered in Firestore responds to `/health`.
+  - Requires Google Cloud credentials with access to the Firestore project.
+  - Run: `python tests/check_health.py`.
+
+- **create_cube_test_env_for_dev.py**
+  - Creates a Kubernetes execution environment through the `EnvironmentManager`.
+  - Needs `kubectl` configured for your cluster and the service account
+    used by the manager.
+  - Run: `python tests/create_cube_test_env_for_dev.py`.
+
+- **run_test_environment_manager.sh**
+  - End-to-end test of the Environment Manager REST API.
+  - Requires a running `environment-manager` pod and `kubectl` access.
+  - Run: `bash tests/run_test_environment_manager.sh`.
+
+- **port_forward_environment_mamager.sh**
+  - Convenience script to port‑forward the Environment Manager to `localhost:8080`.
+  - Run: `bash tests/port_forward_environment_mamager.sh`.
+
+- **run_test_development_agent.sh**
+  - Sends requests to the Development agent running in Kubernetes.
+  - Requires `kubectl` and valid gcloud credentials.
+  - Run: `bash tests/run_test_development_agent.sh`.
+
+- **test_decoposeur.py**
+  - Client for the `DecompositionAgentServer` listening on `localhost:8005`.
+  - Run: `python tests/test_decoposeur.py` (agent must be started first).
+
+- **test_evaluator_client.py**
+  - Client for the `EvaluatorAgentServer` expected on `localhost:8002`.
+  - Run: `python tests/test_evaluator_client.py`.
+
+- **test_reformulator_client.py**
+  - Client for the `ReformulatorAgentServer` expected on `localhost:8001`.
+  - Run: `python tests/test_reformulator_client.py`.
+
+- **test_llm_client.py**
+  - Simple check of the internal LLM client against Vertex AI.
+  - Requires valid Google Cloud credentials.
+  - Run: `python tests/test_llm_client.py`.
+
+- **test_graph_editor_interface.py**
+  - Uses FastAPI's `TestClient` to validate the graph editor endpoints.
+  - Run via `pytest tests/test_graph_editor_interface.py`.
+
+## Unit tests (`tests/unit/`)
+
+Run all unit tests with:
+
+```bash
+pytest tests/unit
+```
+
+Individual files include:
+
+- `test_collaboration_logging.py`
+- `test_context_builder.py`
+- `test_decomposition_logic.py`
+- `test_dev_executor_artifact.py`
+- `test_environment_manager_upload.py`
+- `test_interaction_logger.py`
+- `test_retry_failed_tasks.py`
+- `test_tool_capability_check.py`
+
+Each unit test has no external dependencies and can be run independently
+with `pytest tests/unit/<file>`.

--- a/tests/check_health.py
+++ b/tests/check_health.py
@@ -1,3 +1,9 @@
+"""Utility to verify that registered agents respond to ``/health``.
+
+Requires access to Firestore with ``gcloud auth application-default login``.
+Run with ``python tests/check_health.py``.
+"""
+
 import asyncio
 import httpx
 import firebase_admin

--- a/tests/create_cube_test_env_for_dev.py
+++ b/tests/create_cube_test_env_for_dev.py
@@ -1,3 +1,8 @@
+"""Quick script to manually create a test execution environment on GKE.
+
+Requires Kubernetes credentials and the environment manager service account.
+Execute with ``python tests/create_cube_test_env_for_dev.py``.
+"""
 
 import asyncio
 from src.services.environment_manager import KubernetesEnvironmentManager

--- a/tests/port_forward_environment_mamager.sh
+++ b/tests/port_forward_environment_mamager.sh
@@ -2,6 +2,12 @@
 #!/bin/bash
 set -e
 
+# Helper script to port-forward the Environment Manager service to
+# ``localhost:8080``. Useful when running the manual environment manager tests.
+# Usage:
+#     bash tests/port_forward_environment_mamager.sh
+
+
 NAMESPACE="default"
 LABEL_SELECTOR="app=environment-manager"
 LOCAL_PORT=8080

--- a/tests/run_test_development_agent.sh
+++ b/tests/run_test_development_agent.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+# Manual test that interacts with the Development agent running in a Kubernetes
+# cluster. Requires ``kubectl`` and valid gcloud credentials. Execute with:
+#
+#     bash tests/run_test_development_agent.sh
+
+
 NAMESPACE="default"
 LABEL_SELECTOR="app=development-agent"
 LOCAL_PORT=8080

--- a/tests/run_test_environment_manager.sh
+++ b/tests/run_test_environment_manager.sh
@@ -2,6 +2,13 @@
 #!/bin/bash
 set -e
 
+# Manual end-to-end test of the Environment Manager. Requires ``kubectl`` access
+# to a cluster where the service is deployed. Run directly from the repository
+# root:
+#
+#     bash tests/run_test_environment_manager.sh
+
+
 NAMESPACE="default"
 LABEL_SELECTOR="app=environment-manager"
 LOCAL_PORT=8080

--- a/tests/test_decoposeur.py
+++ b/tests/test_decoposeur.py
@@ -1,3 +1,16 @@
+"""Integration test for the DecompositionAgent.
+
+This script sends a sample plan to a running DecompositionAgentServer and
+displays the returned artifacts. The agent must be accessible locally on
+``http://localhost:8005`` (see ``DECOMPOSITION_AGENT_SERVER_URL``).
+
+Run it manually with:
+
+```bash
+python tests/test_decoposeur.py
+```
+"""
+
 import asyncio
 import httpx
 import logging

--- a/tests/test_evaluator_client.py
+++ b/tests/test_evaluator_client.py
@@ -1,3 +1,9 @@
+"""Integration test for the Evaluator agent.
+
+This script connects to a running ``EvaluatorAgentServer`` defined by
+``EVALUATOR_AGENT_SERVER_URL`` and sends a simple plan for evaluation.
+Run with ``python tests/test_evaluator_client.py``.
+"""
 
 import asyncio
 import httpx

--- a/tests/test_graph_editor_interface.py
+++ b/tests/test_graph_editor_interface.py
@@ -1,3 +1,9 @@
+"""Unit test for the graph editor FastAPI interface.
+
+Run with ``pytest tests/test_graph_editor_interface.py``. No external services
+are required as dummy implementations are used.
+"""
+
 import types
 import sys
 import pytest

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,3 +1,9 @@
+"""Simple manual test for the internal LLM client using Vertex AI.
+
+Ensure Google Cloud credentials are configured in the environment before
+running. Execute with ``python tests/test_llm_client.py``.
+"""
+
 import asyncio
 import os
 import logging

--- a/tests/test_reformulator_client.py
+++ b/tests/test_reformulator_client.py
@@ -1,3 +1,9 @@
+"""Integration test for the Reformulator agent.
+
+The script contacts a ``ReformulatorAgentServer`` (see
+``REFORMULATOR_AGENT_SERVER_URL``) to send a user objective and wait for the
+reformulated version. Execute with ``python tests/test_reformulator_client.py``.
+"""
 
 import asyncio
 import httpx


### PR DESCRIPTION
## Summary
- expand the test README and add a detailed `TESTS_GUIDE.md`
- document prerequisites directly in test files

## Testing
- `pytest -q tests/unit/test_tool_capability_check.py`

------
https://chatgpt.com/codex/tasks/task_e_687befa1fbec832db14a38602c5a1c0b