### PR TITLE
Add agent testing protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ pip install -r requirements.txt
 pip install -r tests/requirements.txt
 pytest
 ```
+For detailed steps to test each agent individually, see `docs/TEST_PROTOCOL.md`.
 
 ## Future Enhancements
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
 # Docs
 
-This folder stores images and resources for the technical documentation. Architecture diagrams referenced by the main README are kept here. Screenshots of the Streamlit interface can also live in this directory. See `environment_manager.md` for details about managing isolated environments.
+This folder stores images and resources for the technical documentation. Architecture diagrams referenced by the main README are kept here. Screenshots of the Streamlit interface can also live in this directory. See `environment_manager.md` for details about managing isolated environments. The file `TEST_PROTOCOL.md` lists step‑by‑step instructions to verify each agent locally.

--- a/docs/TEST_PROTOCOL.md
+++ b/docs/TEST_PROTOCOL.md
@@ -1,0 +1,76 @@
+# Protocole de tests des agents
+
+Ce document décrit la procédure pour vérifier individuellement le bon fonctionnement de chaque agent du projet **OrchestrAI**.
+
+## 1. Préparation commune
+
+1. Installer les dépendances principales puis celles dédiées aux tests :
+   ```bash
+   pip install -r requirements.txt
+   pip install -r tests/requirements.txt
+   ```
+2. Lancer la batterie de tests unitaires et d'intégration :
+   ```bash
+   pytest
+   ```
+   Certains tests nécessitent l'accès à Google Cloud (Firestore, Vertex AI, GKE) et peuvent échouer si ces services ne sont pas configurés.
+
+## 2. Vérification agent par agent
+
+Chaque agent peut être exécuté localement via son serveur A2A puis testé avec le script associé du dossier `tests/`.
+
+### Decomposition Agent
+1. Démarrer le serveur :
+   ```bash
+   python -m src.agents.decomposition_agent.server
+   ```
+2. Exécuter le client de test :
+   ```bash
+   python tests/test_decoposeur.py
+   ```
+
+### Development Agent
+1. Démarrer le serveur ou disposer d'un pod accessible via `kubectl`.
+2. Lancer le script d'intégration :
+   ```bash
+   bash tests/run_test_development_agent.sh
+   ```
+   Ce test envoie une tâche simple et vérifie qu'un artefact est généré.
+
+### Environment Manager
+1. Assurer la présence du service dans votre cluster Kubernetes.
+2. Utiliser le script :
+   ```bash
+   bash tests/run_test_environment_manager.sh
+   ```
+   Celui‑ci crée un environnement, télécharge un fichier, l'exécute puis supprime le pod.
+
+### Evaluator, Reformulator et Validator
+1. Démarrer chaque serveur avec la commande `python -m src.agents.<agent>.server`.
+2. Lancer les clients correspondants :
+   ```bash
+   python tests/test_evaluator_client.py
+   python tests/test_reformulator_client.py
+   ```
+   Les réponses retournées sont affichées dans la console.
+
+### User Interaction Agent
+1. Démarrer le serveur :
+   ```bash
+   python -m src.agents.user_interaction_agent.server
+   ```
+2. Exécuter l'exemple de simulation :
+   ```bash
+   python tests/simule_UserInteractionAgentLogic.py
+   ```
+
+### Testing Agent
+Cet agent s'exécute généralement après le Development Agent. Une fois un projet généré, il peut être appelé via :
+```bash
+python -m src.agents.testing_agent.server
+```
+Les tests à proprement parler dépendent du code produit et sont donc déclenchés par le plan d'exécution.
+
+## 3. Validation finale
+
+Une fois tous les tests terminés sans erreur, les agents peuvent être déployés sur les environnements Cloud Run ou GKE. Pour plus de détails sur la mise en production, se référer aux scripts du dossier `scripts/` et à la documentation principale du dépôt.

--- a/tests/unit/test_collaboration_logging.py
+++ b/tests/unit/test_collaboration_logging.py
@@ -16,8 +16,13 @@ class DummyAgent(BaseAgentLogic):
 @pytest.mark.asyncio
 async def test_record_collaboration_builds_and_logs():
     artifact = {"interaction_id": "abc123"}
-    with patch("src.shared.interaction_logger.build_collaboration_artifact", return_value=artifact) as build_mock,
-         patch("src.shared.interaction_logger.log_collaboration_trace") as log_mock:
+    with (
+        patch(
+            "src.shared.interaction_logger.build_collaboration_artifact",
+            return_value=artifact,
+        ) as build_mock,
+        patch("src.shared.interaction_logger.log_collaboration_trace") as log_mock,
+    ):
         interaction_id = BaseAgentLogic._record_collaboration(
             sender_agent="A",
             receiver_agent="B",
@@ -55,9 +60,17 @@ async def test_send_collaborative_message_records_interaction():
     fake_artifact.parts = [MagicMock(root=MagicMock(text="{\"foo\": \"bar\"}"))]
     fake_task.artifacts = [fake_artifact]
 
-    with patch("src.shared.base_agent_logic.get_firestore_client", return_value=db_mock),
-         patch("src.shared.base_agent_logic.call_a2a_agent", AsyncMock(return_value=fake_task)) as call_mock,
-         patch.object(BaseAgentLogic, "_record_collaboration") as record_mock:
+    with (
+        patch(
+            "src.shared.base_agent_logic.get_firestore_client",
+            return_value=db_mock,
+        ),
+        patch(
+            "src.shared.base_agent_logic.call_a2a_agent",
+            AsyncMock(return_value=fake_task),
+        ) as call_mock,
+        patch.object(BaseAgentLogic, "_record_collaboration") as record_mock,
+    ):
         result = await agent.send_collaborative_message(
             "other",
             "CAPABILITY_CHECK",


### PR DESCRIPTION
## Summary
- fix context manager syntax in `test_collaboration_logging`
- document how to validate each agent in `docs/TEST_PROTOCOL.md`
- reference the new protocol in docs and README

## Testing
- `pip install -r requirements.txt`
- `pip install -r tests/requirements.txt`
- `pytest -q` *(fails: ConfigException: Service host/port is not set)*

------
https://chatgpt.com/codex/tasks/task_e_687caf037ee4832d86bf9ad8d9ae5625